### PR TITLE
fix #34

### DIFF
--- a/src/processor/modify.rs
+++ b/src/processor/modify.rs
@@ -177,10 +177,12 @@ impl Processor for Modify {
     if line.is_empty() {
      continue;
     }
-    let mut line = line.split_whitespace();
-    let to_replacer = line.next().unwrap().to_string();
+    // lineを最後の空白文字で分割
+    let mut line = line.rsplitn(2, ' ');
     let from_matcher = line.next().unwrap().to_string();
     let from_matcher = regex::Regex::new(&from_matcher)?;
+    let to_replacer = line.next().unwrap().to_string();
+    log::warn!("{} -> {}", from_matcher, to_replacer);
     p.regexes.push((to_replacer, from_matcher));
    }
   }


### PR DESCRIPTION
《MODify》の regex のテキストファイルの区切りを最初の空白文字から最後の空白文字に変更します