### PR TITLE
docs: add Flowgraph and runtime mode roadmaps

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,8 @@
 Virtual Avatar Connect の全フェーズ × サブフェーズ単位のチェックボックス一覧。
 各フェーズの詳細設計は `docs/roadmap/phase-*.md`（UNVET の `docs/plan.md` 相当）を参照。
 全体方針・レイヤ構成・Commit Granularity Rule は [`architecture.md`](architecture.md) を参照。
+VAC Flowgraph を常駐型汎用データフロー処理エンジン、および汎用プログラミング言語に近い実行記述へ伸ばす横断計画は [`roadmap/flowgraph-language-roadmap.md`](roadmap/flowgraph-language-roadmap.md) を参照。
+VAC 常駐化に伴う配信・日常・仕事・睡眠などの動作状態切替計画は [`roadmap/runtime-mode-roadmap.md`](roadmap/runtime-mode-roadmap.md) を参照。
 
 ---
 
@@ -184,6 +186,20 @@ Flowgraph engine に **SI 準拠の単位次元システム**を第一級概念�
 ---
 
 ## Backlog / Future
+
+### Flowgraph Language Roadmap
+
+VAC Flowgraph を「設定ファイル」ではなく、常駐型ランタイムへロードされる **プログラム**として扱うための横断計画。既存 Phase δ / λ / ξ / π / ο / M / ρ... を置き換えず、サブグラフ関数化（λ+）、コレクション処理、第一級 `Result` / `Record` / `Bytes` / `MotionFrame` 型、永続 state、capability、debug/test runner を順序立てる上位設計として管理する。
+
+- 仕様草案: [`roadmap/flowgraph-language-roadmap.md`](roadmap/flowgraph-language-roadmap.md)
+- 次の文書化候補: Flowgraph Language Spec、λ+ graph-as-node detailed spec、Flowgraph fixture test runner 設計
+
+### Runtime Mode Roadmap
+
+VAC を常駐型データフローアプリとして動かし続ける前提で、配信・日常・仕事・睡眠・RTA などのユーザー状態に合わせた runtime mode 切替を扱う横断計画。`conf` profile の丸ごと切替ではなく、Flowgraph file / group activation、AI assistant、通知、Managed App desired state を runtime 差分適用する設計として管理する。
+
+- 仕様草案: [`roadmap/runtime-mode-roadmap.md`](roadmap/runtime-mode-roadmap.md)
+- 初期 Flowgraph node 方針: `flowgraph.mode.get` / `flowgraph.mode.equals` / `flowgraph.mode.transit` の 3 種に絞る。`on_transit` 専用 ingress node は初期実装しない。
 
 ### Phase ρ — OSC / VMC / VRC bridge (TBD)
 

--- a/docs/roadmap/flowgraph-language-roadmap.md
+++ b/docs/roadmap/flowgraph-language-roadmap.md
@@ -1,0 +1,666 @@
+# VAC Flowgraph Language Roadmap
+
+> Status: accepted design draft for PR review. 本書は VAC Flowgraph を「常駐型汎用データフロー処理エンジン」および「汎用プログラミング言語に近い実行記述」へ進化させるための上位計画である。個別実装フェーズの正本ではなく、既存 Phase δ / λ / ξ / π / ο / M / ρ... を接続する設計判断メモとして扱う。§8 の Decisions は実装時の前提として扱う。
+
+---
+
+## 0. 結論
+
+VAC はすでに、単なる配信補助ツールではなく **常駐型データフロー処理エンジン**として成立し始めている。Flowgraph はそのエンジン上で動く **プログラム**であり、`.flowgraph.toml` は source format、GUI は editor / IDE、Control API は runtime control / debugger に相当する。
+
+今後の主眼は「ノード数をただ増やす」ことではない。汎用言語へ近づけるには、以下を順に固める必要がある。
+
+1. Flowgraph の言語仕様を明文化する
+2. サブグラフを関数・ライブラリとして再利用できるようにする
+3. 反復・コレクション処理を安全な形で導入する
+4. `json` 逃げを減らし、第一級型を増やす
+5. エラー・状態・権限・デバッグをランタイム機能として揃える
+
+---
+
+## 1. 現状の到達点
+
+### 1.1 Engine
+
+`src/flowgraph/engine.rs` / `src/flowgraph/node.rs` は、すでにプログラミング言語処理系の中核に近い。
+
+- `PureNode` / `StatefulNode` / `EffectfulNode` による副作用分類
+- exec DAG と data DAG の分離
+- data 側の pull-demand lazy evaluation
+- generation 単位の memoization
+- `TriggerHandle` / `TriggerEvent` による常駐 event loop
+- external ingress / self ingress / Control API trigger の統一経路
+
+これは、UE Blueprint 型の exec graph と、純粋関数型言語に近い lazy data graph を混ぜた実行モデルである。
+
+### 1.2 Type System
+
+`src/flowgraph/socket.rs` は、すでに primitive の列挙を超えている。
+
+- `bool` / `int` / `float` / `string` / `json`
+- `list<T>` / `map<T>`
+- `table`
+- `quantity`
+- `datetime`
+- `exec`
+
+さらに `Quantity` と `DateTime` では、限定的な暗黙 coerce と実行時 validation がある。これは「型は事故を防ぐ砦」という VAC の設計思想を言語仕様に持ち込んだもの。
+
+### 1.3 Libraries
+
+Phase λ で以下が入っている。
+
+- `PortSpec.closed_string_variants`
+- user-defined `[[enums]]`
+- `flowgraph.library.input` / `flowgraph.library.output`
+- `[meta]` 拡張
+- `library_uses`
+- dependency cycle detection
+
+ただし現状の library boundary は v0 stub であり、関数・モジュール・パッケージとして使える段階ではない。
+
+### 1.4 Runtime Position
+
+VAC 本体は `flowgraph_dir` をロードし、Flowgraph worker を常駐 task として起動する。VMC / motion 計画でも、VAC を常駐型 hub として再定義している。つまり Flowgraph は「設定ファイル」ではなく、VAC 常駐ランタイムへロードされる **プログラム単位**である。
+
+---
+
+## 2. 目標モデル
+
+### 2.1 VAC の再定義
+
+```text
+VAC =
+  always-on dataflow runtime
+  + typed Flowgraph programming environment
+  + avatar / stream / AI / motion integration hub
+```
+
+常駐型であることが重要。CLI 一回実行の変換器ではなく、外部イベント、タイマー、Twitch、voice、VMC、GUI 操作を受け続け、状態を持ち、必要に応じて外部 I/O を行う。
+
+### 2.2 Flowgraph の再定義
+
+```text
+VAC Flowgraph =
+  typed node-based programming language
+  + visual editor friendly source format
+  + explicit effect boundary
+  + event driven execution model
+```
+
+Flowgraph は「ノードを並べた設定」ではなく、以下を備えるプログラムとして扱う。
+
+- source file: `*.flowgraph.toml`
+- module / package: directory + `[meta]`
+- function: graph-as-node / library signature
+- type: `SocketType` + future schema metadata
+- effect: `PureNode` / `StatefulNode` / `EffectfulNode`
+- runtime: `FlowgraphProgram` worker
+- debugger: Control API + GUI diagnostics + future trace tools
+
+### 2.3 非目標
+
+Flowgraph を Rust / Python / JavaScript の代替にしない。VAC が必要とする領域は「常駐イベント処理」「外部アプリ連携」「ストリーム・アバター制御」「AI / motion / UI の glue」であり、一般計算すべてをテキスト言語並みに表現する必要はない。
+
+目指すべきは、以下のような領域で十分な表現力を持つ言語。
+
+- event routing
+- stream processing
+- stateful reaction
+- typed transformation
+- external I/O orchestration
+- physical / audio / motion computation
+- user-editable automation
+
+---
+
+## 3. 設計原則
+
+### 3.1 Safety First
+
+危険な外部操作は `EffectfulNode` に閉じる。Pure / Stateful の実装には `ExecCtx` を渡さない現方針を維持する。
+
+将来の `http` / `process` / `window` / `file` / `osc` / `obs` / `system` 系ノードは、capability policy を持つべきである。少なくとも以下を区別する。
+
+- local-only harmless
+- local file read/write
+- network access
+- process control
+- window control
+- account / token using API
+- destructive operation
+
+### 3.2 Explicit Boundaries
+
+便利な暗黙変換は限定する。`Float ↔ Quantity` や `String ↔ DateTime` のように、目的が明確で診断可能なものだけにする。
+
+`json` は escape hatch として残すが、言語の中核型を `json` に依存させすぎない。
+
+### 3.3 Bounded Generality
+
+反復や再帰は強力だが、常駐ランタイムでは runaway の危険が高い。最初に導入する制御構造は bounded であるべき。
+
+- `list.map`
+- `list.filter`
+- `list.reduce`
+- `table.filter`
+- `table.select`
+- `table.map_rows`
+- bounded repeat
+
+無制限 loop / recursive graph call は後回し。
+
+### 3.4 Editor First, Not Editor Only
+
+GUI で自然に扱えることを重視する。ただし source format は手で読める必要がある。GUI 専用の hidden state で意味論を作らない。
+
+`.flowgraph.toml` は program source、GUI はその editor。
+
+### 3.5 Runtime Observability
+
+常駐エンジンでは、実行中に何が起きているか見えることが言語機能の一部になる。
+
+- load diagnostics
+- runtime errors
+- node trace
+- last value watch
+- trigger history
+- state snapshot
+- reload diff
+- performance counters
+
+---
+
+## 4. Language Gaps
+
+### 4.1 Abstraction Gap
+
+現状の library boundary は単一 `string` の stub。汎用言語に近づけるには、サブグラフを「関数」として呼べる必要がある。
+
+必要な機能:
+
+- dynamic boundary ports
+- typed signature
+- graph-as-node instantiation
+- input default values
+- output contract
+- exec boundary
+- nested library dependency
+- version / compatibility metadata
+
+### 4.2 Control Gap
+
+現在の制御は `branch` / `gate` / `sequence` / state / timer が中心。反復やコレクション変換が弱い。
+
+必要な機能:
+
+- list / table iteration
+- bounded repeat
+- map/filter/reduce
+- join / group / aggregate
+- event windowing
+- debounce / throttle 以上の stream operator
+
+### 4.3 Type Gap
+
+`Quantity` / `DateTime` は良い方向。だがまだ多くが `json` に逃げている。
+
+今後導入する第一級型:
+
+- `bytes`
+- `record`
+- `result`
+- `option`
+- `motion_frame`
+- `osc_packet`
+- `http_response`
+- `window_handle`
+- `process_handle`
+- `audio_buffer`
+
+すべてを一気に入れない。最初に `result` / `bytes` / `record` を基礎型として導入する。
+
+### 4.4 Error Gap
+
+現状は以下が混在する。
+
+- `NodeExecError` として engine error
+- `on_error` exec + `error: string`
+- warning diagnostics
+- log trace
+
+汎用ランタイム化するなら、recoverable error と fatal error の規約をそろえる必要がある。
+
+採用する方針:
+
+- validation error: load 時に止める
+- recoverable runtime error: `on_error` / `Result` 出力
+- fatal runtime error: worker diagnostics に積むが process は落とさない
+- programmer error: test / debug で即検出
+
+### 4.5 State Gap
+
+`StatefulNode` の state は worker 内メモリ。reload / restart / profile switch を跨ぐ永続状態は別設計が必要。
+
+必要な機能:
+
+- graph-scoped key-value state
+- typed state slot
+- snapshot
+- import / export
+- reload migration
+- state reset policy
+- profile-local vs global scope
+
+### 4.6 Package Gap
+
+`library_uses` は依存グラフの始まりだが、パッケージとしては不足がある。
+
+必要な機能:
+
+- public signature
+- semantic version
+- compatibility range
+- examples
+- tests
+- docs metadata
+- lockfile or resolved dependency record
+
+### 4.7 Debug Gap
+
+GUI editor はあるが、runtime debugger としてはまだ弱い。
+
+必要な機能:
+
+- run graph once with fixture input
+- trigger selected node with inputs
+- watch port values
+- inspect last N triggers
+- step exec chain
+- show data pull tree
+- show effect boundary
+- export trace bundle
+
+---
+
+## 5. Proposed Stages
+
+### Stage 0 — Language Positioning
+
+目的: VAC Flowgraph を「プログラム」として扱う上位方針を文書化する。
+
+成果物:
+
+- 本書
+- `roadmap.md` から本書への入口
+- `architecture.md` に反映する場合は、本書承認後の別 PR で「Flowgraph as Program Runtime」節として扱う
+
+実装は行わない。
+
+### Stage 1 — Language Spec Consolidation
+
+目的: 既存仕様を再整理し、Flowgraph の言語仕様として読める文書を作る。
+
+対象:
+
+- execution model
+- type model
+- effect model
+- file/module model
+- diagnostics model
+- reload model
+- compatibility policy
+
+既存の `phase-delta-spec.md` は基礎仕様として残す。統合視点は新しい開発者向け正本文書 `docs/roadmap/flowgraph-language-spec.md` に集約し、ユーザー向け短縮版は必要になった段階で `docs/manual/flowgraph-language.md` として派生させる。
+
+採用する文書構成:
+
+- `docs/roadmap/flowgraph-language-spec.md`: 開発者向け正本
+- `docs/manual/flowgraph-language.md`: ユーザー向け短縮版（language spec が固まった後に作成）
+
+### Stage 2 — λ+ Graph-as-Node
+
+目的: サブグラフを関数・ライブラリとして呼べるようにする。
+
+主な設計:
+
+- `flowgraph.library.input` / `output` の dynamic ports
+- boundary node を source of truth として signature を生成
+- `[meta.signature]` は将来の cache / public API 表現として生成・検証対象にする
+- graph-as-node catalog entry
+- library instance properties
+- exec input / output boundary
+- internal node id namespace
+- diagnostic mapping from instance back to source graph
+
+最初のスコープ:
+
+- 1 file = 1 library function
+- acyclic dependency only
+- no recursion
+- no dynamic type parameter
+- no variadic ports
+
+実装単位:
+
+1. docs: λ+ detailed spec
+2. loader: signature extraction
+3. engine: subprogram instance node
+4. GUI: catalog entry + boundary editor
+5. tests: sample library + graph-as-node execution
+
+### Stage 3 — Collection Processing
+
+目的: 反復を安全な関数型コレクション操作として導入する。
+
+採用する初期ノード群:
+
+- `flowgraph.list.map`
+- `flowgraph.list.filter`
+- `flowgraph.list.reduce`
+- `flowgraph.table.filter`
+- `flowgraph.table.select`
+- `flowgraph.table.map_rows`
+- `flowgraph.table.aggregate`
+
+実装上の制約:
+
+- ノードがサブグラフを引数として取る必要がある
+- `map` には callback graph signature が必要
+- callback graph は Stage 3 v0 では Pure only に制限する
+- Effectful callback は禁止する
+- Stateful callback は Stage 3 v0 では禁止し、必要になった段階で persistent graph state との整合を取って別途解禁する
+
+実行保護:
+
+- max_items / timeout / cancellation を持つ
+
+### Stage 4 — Result / Error Type
+
+目的: recoverable error を String + `on_error` から第一級値へ段階移行する。
+
+採用する型:
+
+```text
+result<T>
+  ok: bool
+  value: T?
+  error: string?
+  code: string?
+```
+
+実装上は `SocketType::Result(Box<SocketType>)` として表現する。`value` の型は `T`、`error` / `code` は `string`、`ok` は `bool` とする。
+
+最初の対象:
+
+- HTTP
+- JSON parse
+- DateTime parse
+- unit parse
+- Twitch / OBS / OSC I/O
+
+互換性:
+
+- 既存 `on_success` / `on_error` は残す
+- data 出力として `result` を追加
+- GUI は Result port を専用表示
+
+### Stage 5 — Record / Schema Type
+
+目的: `json` の乱用を減らし、構造データを型付きで扱う。
+
+採用する型表現:
+
+- named schema in `[types]`
+- `record<schema_id>` を socket type 表記として使う
+- table row schema は named schema を参照して再利用する
+
+最初の用途:
+
+- VMC `MotionFrame`
+- OSC packet
+- HTTP response
+- Twitch event
+- AI tool call payload
+
+方針:
+
+- まずは named schema metadata + runtime validation
+- full structural type equality は後回し
+- GUI 表示と docs generator を優先
+
+### Stage 6 — Persistent Graph State
+
+目的: 常駐ランタイムとして reload / restart を跨ぐ state を扱う。
+
+採用する初期ノード群:
+
+- `flowgraph.state.kv_get`
+- `flowgraph.state.kv_set`
+- `flowgraph.state.kv_delete`
+- `flowgraph.state.snapshot`
+- `flowgraph.state.restore`
+
+採用する設計:
+
+- profile-local state path
+- graph fq name と state key namespace
+- version migration
+- secret と通常 state の分離
+- crash-safe write
+
+保存形式は既存 `state_data_path` との整合を優先して決める。Stage 6 の設計文書で、既存永続化との互換性を確認したうえで wire format を確定する。
+
+### Stage 7 — Capability Model
+
+目的: 汎用外部 I/O ノードを安全に増やす。
+
+対象:
+
+- `flowgraph.http.request`
+- `flowgraph.file.*`
+- `flowgraph.process.*`
+- `flowgraph.window.*`
+- `flowgraph.obs.*`
+- `flowgraph.osc.*`
+- `flowgraph.system.*`
+
+最初に必要なもの:
+
+- capability declaration in node specs
+- config-level allow/deny
+- GUI warning
+- LAN control policyとの整合
+- destructive operation confirmation
+
+採用する config 形:
+
+```toml
+[flowgraph.capabilities]
+network = "allow_local_only"
+file_read = ["./data", "./flowgraph"]
+file_write = ["./data"]
+process = "deny"
+window_control = "deny"
+```
+
+### Stage 8 — Debugger / Test Runner
+
+目的: Flowgraph をプログラムとして保守できるテスト・デバッグ基盤を作る。
+
+採用する初期機能:
+
+- `vac flowgraph test`
+- `*.flowgraph.test.toml`
+- fixture trigger
+- expected trace
+- expected channel output
+- expected state diff
+- expected diagnostics
+
+GUI:
+
+- selected node trigger
+- watch port
+- trigger timeline
+- last error panel
+- data pull tree viewer
+
+---
+
+## 6. Priority
+
+### P0: Now
+
+- 本書を承認可能な設計文書にする
+- `roadmap.md` に本書への入口を追加
+- `architecture.md` への反映は別 PR に分離する
+
+### P1: Next Design
+
+- Flowgraph Language Spec
+- λ+ graph-as-node detailed spec
+- Debug/test runner の最小仕様
+
+### P2: First Implementation Tracks
+
+Cursor 側の M 系や GUI 作業と衝突しにくい初期実装トラック:
+
+- docs-only language spec
+- loader-level library signature extraction
+- Flowgraph fixture test runner
+- `Result` 型の設計のみ
+- node catalog metadata 拡張
+
+### P3: Larger Implementation
+
+- graph-as-node runtime
+- collection higher-order nodes
+- persistent graph state
+- capability model
+
+---
+
+## 7. Interaction with Existing Phases
+
+### Phase δ
+
+δ は基礎仕様。今後も「Flowgraph の最小意味論」の参照元として残す。本書は δ を置き換えない。
+
+### Phase λ
+
+λ は enum / library v0。汎用言語化の最初の本丸は λ+ である。dynamic boundary ports と graph-as-node はここに接続する。
+
+### Phase ξ / π
+
+Quantity / DateTime は型システム拡張の成功例。今後の `record` / `result` / `bytes` / `motion_frame` も、同じように「事故を型で防ぐ」方針で設計する。
+
+### Phase ο
+
+math / vec / signal util / random / noise / timer は計算ライブラリとしての基盤。collection / physics / audio-reactive はここから伸びる。
+
+### Phase M
+
+M は VAC を常駐型 motion hub として外へ広げる実用線。`MotionFrame` は record/schema 型導入の有力な最初の利用者。
+
+### Phase ρ / σ / τ / υ / ω
+
+これらは外部 I/O、GUI、audio/physics など個別領域の拡張。言語化ロードマップは横串として、capability、debug、type、package の共通設計を与える。
+
+---
+
+## 8. Decisions
+
+### 8.1 Dynamic Boundary Port Source of Truth
+
+Library signature は boundary node の property から生成する。v0 では boundary node が source of truth であり、GUI は boundary node を編集対象にする。
+
+`[meta.signature]` は v0 の手書き source of truth にはしない。将来の cache / public API 表現として生成し、存在する場合は loader が boundary node 由来の signature と整合検証する。
+
+### 8.2 Graph-as-Node and State
+
+ライブラリ内 StatefulNode の state は、呼び出しインスタンスごとに分離する。graph-as-node の各 instance は instance-local state を持つ。shared state が必要な場合は、Stage 6 の persistent graph state を明示的に使う。
+
+### 8.3 Effectful Subgraphs
+
+Effectful node を含む library も graph-as-node 化できる。ただし graph-as-node 自体の effect class は内包ノードから推論する。
+
+- pure only -> Pure
+- stateful included, no effectful -> Stateful
+- effectful included -> Effectful
+
+これにより `PureNode` から effectful graph を pull できない現行安全性を保てる。
+
+### 8.4 Higher-order Graphs
+
+`list.map` が callback graph を受け取ると、Flowgraph は高階関数を持つことになる。
+
+Stage 3 では callback graph を pure-only に制限する。Effectful iteration は明示的な bounded exec loop として別扱いにする。
+
+### 8.5 Text Language
+
+TOML 以外のテキスト DSL は当面導入しない。TOML source + GUI editor + fragment ZIP の整理を優先する。DSL は graph-as-node / signature / schema が固まった後の別フェーズで扱う。
+
+### 8.6 Compatibility
+
+Flowgraph source format の互換性は以下で保証する。
+
+- load-time warning for deprecated feature
+- migration tool where possible
+- node feature rename table
+- `schema_version` は必要になった時点で `[meta]` に追加
+
+---
+
+## 9. Suggested First PR Series
+
+### PR 1: docs-flowgraph-language-roadmap
+
+Scope:
+
+- 本書
+- `roadmap.md` link
+
+No code.
+
+### PR 2: docs-flowgraph-language-spec
+
+Scope:
+
+- execution / type / effect / file model を統合した language spec draft
+- existing docs への cross-link
+
+No code.
+
+### PR 3: docs-lambda-plus-graph-as-node
+
+Scope:
+
+- λ+ detailed spec
+- dynamic boundary port design
+- graph-as-node implementation plan
+- tests plan
+
+No code.
+
+### PR 4: test-flowgraph-fixture-runner
+
+Scope:
+
+- 最小 lib test helper
+- existing examples を fixture として実行
+- no GUI changes
+
+Cursor 側の GUI / motion 実装と衝突しにくい。
+
+---
+
+## 10. Acceptance Criteria for This Roadmap
+
+本書が承認される条件:
+
+- VAC を常駐型汎用データフローエンジンとして扱う方針が明確
+- Flowgraph をプログラムとして扱う用語が明確
+- 既存 Phase との衝突がない
+- 実装順が「抽象化 → 反復 → 型 → state/error/debug/capability」の形で読み取れる
+- すぐ実装しない大物が、後続フェーズとして隔離されている

--- a/docs/roadmap/runtime-mode-roadmap.md
+++ b/docs/roadmap/runtime-mode-roadmap.md
@@ -1,0 +1,379 @@
+# VAC Runtime Mode Roadmap
+
+> Status: accepted design draft for PR review. 本書は VAC が「配信時だけ起動する支援アプリ」から「常駐型データフローアプリ」へ移行することに伴い、ユーザーの現在状態に合わせて VAC の動作状態を滑らかに切り替えるための上位計画である。実装時は `conf` / profile / Flowgraph activation / Managed App desired state を明確に分離する。
+
+---
+
+## 0. 結論
+
+VAC v0 当初の主用途は、VStreamer が配信時に起動する AI パートナー機能付き配信支援アプリだった。v2 構想では VAC は常駐型データフローアプリへ移行する。したがってユーザーは、配信していない間も VAC を動かし続け、日常・仕事・睡眠・ゲーム・RTA などの現在状態に応じて動作を切り替えたくなる。
+
+この切替は `conf.toml` の丸ごと差し替えではなく、VAC runtime 上の **Runtime Mode** として扱う。
+
+Runtime Mode は以下をまとめる。
+
+- Flowgraph file / group の有効化状態
+- AI assistant / persona / heartbeat の動作状態
+- Managed App の desired state
+- ingress / notification / capability policy
+- mode 遷移時に発行される runtime event
+
+`conf` profile は起動環境の粗い切替、Runtime Mode は常駐中の滑らかな動作状態切替である。
+
+---
+
+## 1. 背景
+
+### 1.1 v0 の前提
+
+v0 当初の VAC は、配信時に立ち上げて使うアプリとして設計されていた。この前提では、OBS / Warudo / TTS / AI 会話 / Twitch 連携などを「配信中に必要なもの」としてまとめて起動しても成立した。
+
+### 1.2 v2 の前提
+
+v2 構想の VAC は常駐型データフローアプリである。VAC はユーザーの PC 上で長時間動作し、必要な Flowgraph だけを維持し、通知・外部イベント・AI 会話・motion hub・配信補助を状況に応じて切り替える。
+
+この前提では、配信していない日常状態で OBS / Warudo / TTS を常時起動するのは負荷と認知ノイズになる。一方で、日常状態でも AI assistant と雑談したいユーザー、緊急地震速報や RSS 更新だけ受けたいユーザー、仕事中は通知を絞りたいユーザー、睡眠中は critical alert だけ欲しいユーザーがいる。
+
+VAC はこの差を mode として扱う必要がある。
+
+---
+
+## 2. 用語
+
+### 2.1 Conf Profile
+
+`conf.toml` または profile API で扱う起動設定。API token、root directory、motion backend、Control API bind address など、VAC プロセスの基本環境を表す。
+
+Profile は粗い切替であり、頻繁な mode transition の主手段にはしない。
+
+### 2.2 Runtime Mode
+
+VAC 常駐中に切り替える現在の動作状態。例:
+
+- `daily`
+- `streaming`
+- `work`
+- `sleep`
+- `rta`
+- `game:<title>`
+
+Runtime Mode は conf を置き換えず、現在起動中の runtime に overlay として適用される。
+
+### 2.3 Flowgraph Activation
+
+ロード済み Flowgraph file / group を runtime 上で有効化・無効化する状態。初期実装では file / group 単位を基本にする。node 単位 pause/resume は後段の拡張。
+
+### 2.4 Managed App Desired State
+
+`run_with` 由来の外部アプリに対する mode 別の目標状態。例:
+
+- `start`
+- `stop`
+- `minimize`
+- `leave`
+
+Mode Manager は現在状態との差分を取り、必要な start / stop / minimize を実行する。
+
+---
+
+## 3. 設計原則
+
+### 3.1 Mode は runtime の責務
+
+Mode 切替は Flowgraph 自身ではなく、VAC runtime の責務である。
+
+Flowgraph 内に「自分や他の Flowgraph を ON/OFF するノード」を主機構として置くと、止めたい Flowgraph が動いていることに停止処理が依存する。また、mode の全体整合性が各 Flowgraph に分散し、GUI や Control API から現在状態を理解しにくくなる。
+
+### 3.2 Conf 丸ごと reload は主手段にしない
+
+指定 conf へ切り替えて reload する方式でも大雑把な mode 切替は可能だが、常駐アプリの体験としては粗い。
+
+Runtime Mode は差分適用を基本にする。起動環境そのものを変える必要がある場合だけ profile / restart を使う。
+
+### 3.3 Flowgraph 側 API は最小にする
+
+Flowgraph は mode を観測し、判定し、遷移を要求できれば十分である。初期実装で追加する mode 系ノードは以下に絞る。
+
+- `flowgraph.mode.get`
+- `flowgraph.mode.equals`
+- `flowgraph.mode.transit`
+
+`on_transit` ingress node は初期実装しない。理論上は存在しうるが、`mode_changed` runtime event を既存 trigger / event 系へ流せば足りる。専用 ingress を増やすと、ユーザーに「mode 切替を検知する方法」が複数あるように見え、混乱を招く。
+
+### 3.4 File / group 単位を初期粒度にする
+
+初期粒度は Flowgraph file / group 単位にする。node 単位 activation は強力だが、実行中 state、edge、memoization、GUI 表示、debugger の扱いが複雑になる。
+
+ファイル名を `.flowgraph.toml.disabled` に物理変更する手法は手動運用には使えるが、滑らかな runtime transition の中核にはしない。Mode Manager は loader metadata と runtime state で有効化状態を管理する。
+
+---
+
+## 4. Mode Definition
+
+Runtime Mode は `conf.toml` 内の `[modes.*]` として宣言的に定義する。初期実装では別ファイル `modes.toml` を導入しない。mode は VAC の起動環境に従属する runtime overlay であり、`conf` と同じ validation / profile 管理の対象に置く。
+
+例:
+
+```toml
+[modes.daily]
+display_name = "Daily"
+flowgraph_groups.enable = ["assistant", "alerts", "rss"]
+flowgraph_groups.disable = ["streaming", "avatar"]
+managed_apps.stop = ["obs", "warudo", "tts"]
+ai.enabled = true
+notifications.level = "normal"
+
+[modes.streaming]
+display_name = "Streaming"
+flowgraph_groups.enable = ["assistant", "streaming", "avatar", "obs"]
+managed_apps.start = ["obs", "warudo", "tts"]
+ai.enabled = true
+notifications.level = "stream_safe"
+
+[modes.work]
+display_name = "Work"
+flowgraph_groups.enable = ["assistant", "alerts"]
+managed_apps.stop = ["obs", "warudo", "tts"]
+ai.enabled = true
+notifications.level = "important_only"
+
+[modes.sleep]
+display_name = "Sleep"
+flowgraph_groups.enable = ["emergency_alerts"]
+flowgraph_groups.disable = ["assistant", "streaming", "avatar", "rss"]
+managed_apps.stop = ["obs", "warudo", "tts"]
+ai.enabled = false
+notifications.level = "critical_only"
+```
+
+Mode 定義は「現在 mode に入ったとき、VAC がどの状態へ収束すべきか」を表す。命令列ではなく desired state である。
+
+---
+
+## 5. Flowgraph Metadata
+
+Flowgraph file 側には activation のための metadata を置く。
+
+```toml
+[meta]
+name = "rss-alerts"
+mode_groups = ["rss", "alerts"]
+default_enabled = true
+```
+
+### 5.1 `mode_groups`
+
+Flowgraph を mode から選択するための group。Mode 定義は group を enable / disable する。
+
+### 5.2 `default_enabled`
+
+mode 未設定時、または旧環境での後方互換のために使う既定有効状態。既存 Flowgraph は `default_enabled = true` 相当として扱う。
+
+### 5.3 File ID
+
+Runtime 上では物理 path ではなく、loader が決定する stable file id を使って activation state を持つ。初期実装では canonical relative path を id としてよいが、将来 package / library 化するときは `[meta].id` を導入できる余地を残す。
+
+---
+
+## 6. Transition Semantics
+
+Mode transition は best-effort な差分適用として扱う。完全 transaction / rollback は初期実装の要件にしない。
+
+基本手順:
+
+1. target mode を検証する
+2. 現在 mode との差分 plan を作る
+3. 停止対象 Flowgraph への新規 trigger 投入を止める
+4. 停止対象 Flowgraph を drain できる範囲で quiesce する
+5. 無効化対象 Flowgraph を inactive にする
+6. 停止対象 Managed App を stop / minimize する
+7. 起動対象 Managed App を start する
+8. 有効化対象 Flowgraph を active にする
+9. `mode_changed` event を発行する
+
+Transition API は dry-run を持つ。
+
+```text
+POST /api/v1/control/modes/transit
+GET  /api/v1/control/modes
+GET  /api/v1/control/modes/current
+POST /api/v1/control/modes/plan
+```
+
+`plan` は GUI の確認表示、ログ、テストに使う。
+
+---
+
+## 7. Flowgraph Nodes
+
+### 7.1 `flowgraph.mode.get`
+
+現在 mode id を返す Pure node。
+
+Inputs:
+
+- none
+
+Outputs:
+
+- `mode: string`
+
+### 7.2 `flowgraph.mode.equals`
+
+現在 mode が指定 mode と一致するかを返す Pure node。
+
+Inputs:
+
+- `mode: string`
+
+Outputs:
+
+- `equals: bool`
+
+### 7.3 `flowgraph.mode.transit`
+
+指定 mode への遷移を runtime に要求する Effectful node。
+
+Inputs:
+
+- `exec`
+- `mode: string`
+- `reason: string` optional
+
+Outputs:
+
+- `exec`
+- `accepted: bool`
+- `message: string`
+
+このノードは即座に mode を同期的に切り替えるのではなく、Mode Manager へ transition request を送る。循環遷移を避けるため、同一 mode への transit は no-op、transition 中の再入要求は reject する。
+
+### 7.4 実装しないノード
+
+初期実装では `flowgraph.ingress.mode_transit` / `flowgraph.ingress.on_transit` は追加しない。
+
+Mode 変更を Flowgraph へ通知する必要がある場合は、runtime が `mode_changed` event を既存 event / trigger 経路へ流す。専用 ingress は、既存 event 系では表現できない実ユースケースが出た段階で再検討する。
+
+---
+
+## 8. Managed App Integration
+
+`run_with` は「VAC と一緒に扱う外部アプリ」の registry として維持する。Runtime Mode はその registry に対して desired state を指定する。
+
+例:
+
+```toml
+[[run_with]]
+id = "obs"
+name = "OBS Studio"
+command = "obs64.exe"
+
+[[run_with]]
+id = "warudo"
+name = "Warudo"
+command = "Warudo.exe"
+
+[modes.streaming.managed_apps]
+start = ["obs", "warudo"]
+
+[modes.daily.managed_apps]
+stop = ["obs", "warudo"]
+```
+
+Mode Manager は `run_with` の定義を直接書き換えない。書き換えるのは「mode に入ったときの desired state」だけである。
+
+---
+
+## 9. GUI / UX
+
+GUI は mode を常時表示し、ユーザーが明示的に切り替えられるようにする。
+
+初期 UI:
+
+- current mode indicator
+- mode selector
+- transition plan preview
+- Managed App start / stop 結果
+- active / inactive Flowgraph group 表示
+
+将来 UI:
+
+- schedule based mode transition
+- hotkey / StreamDeck / MIDI trigger
+- per-mode notification policy editor
+- transition failure history
+
+---
+
+## 10. Implementation Roadmap
+
+### RM-0 docs
+
+- 本書を追加
+- `roadmap.md` から参照
+- Flowgraph Language Roadmap との責務分離を明記
+
+### RM-1 data model
+
+- `RuntimeModeId`
+- `RuntimeModeDefinition`
+- `ModeTransitionPlan`
+- `ModeTransitionState`
+- mode validation
+
+### RM-2 Control API
+
+- mode list
+- current mode read
+- dry-run transition plan
+- transition request
+- transition status
+
+### RM-3 Flowgraph activation
+
+- `[meta].mode_groups`
+- `[meta].default_enabled`
+- loader metadata
+- runtime activation state
+- inactive Flowgraph への trigger 抑止
+
+### RM-4 Flowgraph mode nodes
+
+- `flowgraph.mode.get`
+- `flowgraph.mode.equals`
+- `flowgraph.mode.transit`
+- node catalog / GUI palette / tests
+
+### RM-5 Managed App integration
+
+- mode desired state
+- diff application
+- transition result reporting
+
+### RM-6 GUI
+
+- mode selector
+- plan preview
+- active Flowgraph / Managed App state display
+
+### RM-7 advanced policy
+
+- schedule / hotkey transition
+- transition guard
+- notification policy
+- capability policy
+
+---
+
+## 11. Decisions
+
+- Runtime Mode は conf profile とは別概念にする。
+- Runtime Mode 定義は初期実装では `conf.toml` 内の `[modes.*]` に置く。
+- Mode transition は runtime 差分適用を基本にする。
+- 初期 activation 粒度は Flowgraph file / group 単位にする。
+- `.flowgraph.toml.disabled` 物理リネームは runtime mode の主機構にしない。
+- Flowgraph mode node は `get` / `equals` / `transit` の 3 種に絞る。
+- `on_transit` 専用 ingress node は初期実装しない。
+- transition 中の再入要求は queue せず reject する。
+- Managed App は mode から直接定義せず、`run_with` registry に対する desired state として扱う。
+- Transition は初期実装では best-effort。dry-run plan と結果 report を必須にする。


### PR DESCRIPTION
## Summary

- Add `docs/roadmap/flowgraph-language-roadmap.md` for the long-term plan to evolve VAC Flowgraph into a resident general-purpose dataflow runtime and programming model.
- Add `docs/roadmap/runtime-mode-roadmap.md` for runtime mode switching as VAC becomes an always-on dataflow app.
- Link both roadmap documents from `docs/roadmap.md`.

## Notes

- This is a docs-only PR.
- The runtime mode plan fixes the initial Flowgraph mode node surface to `flowgraph.mode.get`, `flowgraph.mode.equals`, and `flowgraph.mode.transit`.
- `on_transit`-style dedicated ingress nodes are intentionally left out of the initial design.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add new planning documents and links; no runtime behavior or APIs are modified in this PR.
> 
> **Overview**
> Adds two new design-roadmap documents: one for evolving Flowgraph into a more *program-like*, always-on dataflow “language” (`flowgraph-language-roadmap.md`), and one for introducing *runtime mode* switching as VAC becomes resident (`runtime-mode-roadmap.md`).
> 
> Updates `docs/roadmap.md` to link these roadmaps and adds brief backlog entries that fix early design constraints (notably keeping the initial mode node surface to `flowgraph.mode.get` / `equals` / `transit`, and explicitly deferring dedicated `on_transit` ingress nodes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb69b68946d430d203aa82ba6231dc54c7a89ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->