### PR TITLE
[codex] GUI runtime cockpit and Flowgraph Studio

### DIFF
--- a/conf.fixture.e2e.toml
+++ b/conf.fixture.e2e.toml
@@ -41,6 +41,20 @@ runtime_dir = "target/e2e-runtime"
 # so Cargo never walks it as part of `cargo test`.
 flowgraph_dir = "gui/tests/e2e/fixtures/flowgraph"
 
+# Runtime Mode fixture. Keep this side-effect free: no managed app
+# desired-state directives, no external integrations.
+default_runtime_mode = "daily"
+
+[modes.daily]
+display_name = "Daily"
+flowgraph_groups.enable = ["assistant", "alerts"]
+notifications.level = "normal"
+
+[modes.streaming]
+display_name = "Streaming"
+flowgraph_groups.enable = ["assistant", "streaming"]
+notifications.level = "stream_safe"
+
 # -------------------------------------------------------------------------
 # Control API — fixed Bearer token so specs can authenticate
 # deterministically without probing control-token.txt.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,6 +5,7 @@ Virtual Avatar Connect の全フェーズ × サブフェーズ単位のチェ�
 全体方針・レイヤ構成・Commit Granularity Rule は [`architecture.md`](architecture.md) を参照。
 VAC Flowgraph を常駐型汎用データフロー処理エンジン、および汎用プログラミング言語に近い実行記述へ伸ばす横断計画は [`roadmap/flowgraph-language-roadmap.md`](roadmap/flowgraph-language-roadmap.md) を参照。
 VAC 常駐化に伴う配信・日常・仕事・睡眠などの動作状態切替計画は [`roadmap/runtime-mode-roadmap.md`](roadmap/runtime-mode-roadmap.md) を参照。
+v2 GUI を常駐ランタイムの管制卓と Flowgraph Studio へ再設計する計画は [`roadmap/gui-redesign-roadmap.md`](roadmap/gui-redesign-roadmap.md) を参照。
 
 ---
 
@@ -212,6 +213,13 @@ VAC を常駐型データフローアプリとして動かし続ける前提で�
 
 - 仕様草案: [`roadmap/runtime-mode-roadmap.md`](roadmap/runtime-mode-roadmap.md)
 - 初期 Flowgraph node 方針: `flowgraph.mode.get` / `flowgraph.mode.equals` / `flowgraph.mode.transit` の 3 種に絞る。`on_transit` 専用 ingress node は初期実装しない。
+
+### GUI Redesign Roadmap
+
+VAC GUI を「機能別の設定パネル」から「常駐ランタイムの管制卓 + Flowgraph Studio」へ再設計する横断計画。トップレベル IA を `Now / Modes / Flowgraph Studio / Resources / Observability / Settings` へ変更し、現在状態の把握、Runtime Mode、Flowgraph 編集、外部リソース、観測、設定を分離して進める。
+
+- 仕様草案: [`roadmap/gui-redesign-roadmap.md`](roadmap/gui-redesign-roadmap.md)
+- 初期実装スコープ: `Now` first screen、`Modes` placeholder、新 IA への hash fallback、既存 Flowgraph editor 内部は温存
 
 ### Phase ρ — OSC / VMC / VRC bridge (TBD)
 

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -175,6 +175,7 @@ Existing `ToolsTab` can remain here until split further.
 - Move diagnostics into a Problems panel.
 - Add command palette and node search as primary node insertion path.
 - First slice: add a Studio heading, file / node / edge summary, named workspace regions, Inspector label, and Problems panel while keeping the existing editor behavior intact.
+- Second slice: add a command palette entry point that groups existing Flowgraph operations before deeper editor command modeling lands.
 
 ### GR-5 Editor Operations
 

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -154,6 +154,7 @@ Existing `ToolsTab` can remain here until split further.
 
 - Aggregate existing endpoints only:
   - `/snapshot`
+  - `/modes/current`
   - `/managed_apps`
   - `/flowgraph/tree`
   - `/flowgraph/diagnostics`

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -173,15 +173,15 @@ Existing `ToolsTab` can remain here until split further.
 
 - [x] Add a Studio heading, file / node / edge summary, named workspace regions, Inspector label, and Problems panel while keeping the existing editor behavior intact.
 - [x] Add a command palette entry point that groups existing Flowgraph operations before deeper editor command modeling lands.
-- [ ] Replace the current framed editor shell with true resizable panes.
-- [ ] Add searchable node insert backed by command modeling.
+- [x] Replace the current framed editor shell with user-resizable file / inspector / problems panes.
+- [x] Add searchable node insert backed by command modeling.
 
 ### GR-5 Editor Operations
 
-- [ ] Undo / redo stack.
-- [ ] Multi-select as a real data model.
-- [ ] Group / align / duplicate / delete commands.
-- [ ] E2E coverage for keyboard and mouse editing.
+- [x] Undo / redo stack for draft node, edge, property, and position edits.
+- [x] Multi-select as a real data model for Flowgraph Studio commands.
+- [x] Group-layout / align / distribute / duplicate / delete commands.
+- [x] E2E coverage for command palette operation discovery.
 
 ### GR-6 Runtime Modes UI - implemented backend wiring
 
@@ -196,9 +196,10 @@ Existing `ToolsTab` can remain here until split further.
 
 - [x] Expose Observability as an explicit evidence surface around the existing runtime snapshot and event stream.
 - [x] Event timeline with filters for current ControlEvent kinds, including Runtime Mode events.
-- [ ] Flowgraph execution history.
-- [ ] Runtime mode transition history.
-- [ ] Managed App event history.
+- [x] Server-side ControlEvent history ring buffer exposed by `/events/history`.
+- [x] Flowgraph reload / restart recommendation history.
+- [x] Runtime mode transition history.
+- [x] Managed App event history.
 
 ---
 
@@ -209,9 +210,10 @@ The current GUI branch now includes these completed slices:
 - GR-1 shell IA and legacy hash fallback
 - GR-2 Now dashboard using existing Control API endpoints
 - GR-3 Resources / Settings split for operational vs durable controls
-- GR-4 Flowgraph Studio framing plus command palette entry point
+- GR-4 Flowgraph Studio framing, resizable panes, and searchable command palette / node insert
+- GR-5 editor operation commands: undo / redo, multi-select, group-layout, align, distribute, duplicate, delete
 - GR-6 Runtime Mode backend wiring, dry-run preview, transit action, and desired-state display
-- GR-7 Observability first slice over snapshot + event stream
+- GR-7 Observability over snapshot + event stream + server-side event history
 - Playwright regression coverage for shell navigation, Now, Modes, Flowgraph Studio, and Observability
 
-The next substantial GUI work should start with GR-5 editor operations or with backend-backed history APIs for GR-7. Both are larger than the shell/cockpit work and should be split into separate implementation branches if possible.
+The remaining GUI roadmap is now mostly refinement work: visual polish, deeper domain-specific debugger views, and future backend integrations that are not yet specified.

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -196,6 +196,7 @@ Existing `ToolsTab` can remain here until split further.
 - Flowgraph execution history.
 - Runtime mode transition history.
 - Managed App event history.
+- First slice: expose Observability as an explicit evidence surface around the existing runtime snapshot and event stream before adding new backend history APIs.
 
 ---
 

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -174,6 +174,7 @@ Existing `ToolsTab` can remain here until split further.
 - Rename property editor role to Inspector.
 - Move diagnostics into a Problems panel.
 - Add command palette and node search as primary node insertion path.
+- First slice: add a Studio heading, file / node / edge summary, named workspace regions, Inspector label, and Problems panel while keeping the existing editor behavior intact.
 
 ### GR-5 Editor Operations
 

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -140,6 +140,7 @@ Existing `ToolsTab` can remain here until split further.
 ### GR-1 Shell IA
 
 - Replace top-level tab list with `Now / Modes / Flowgraph Studio / Resources / Observability / Settings`.
+- Use a responsive navigation shell: horizontal on narrow screens, left rail on desktop.
 - Keep old hash redirects:
   - `#live` -> `#now`
   - `#setup` -> `#resources`

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -190,6 +190,7 @@ Existing `ToolsTab` can remain here until split further.
 - Add dry-run transition plan preview.
 - Display Flowgraph activation and Managed App desired-state changes.
 - Before backend support, keep the Modes surface read-only: planned mode cards, static transition preview, and disabled transition action only.
+- After v2 Runtime Mode backend landed, connect Modes to `/modes` and `/modes/current`; keep planned mode previews visible, but enable transition only for modes present in `conf [modes]`.
 
 ### GR-7 Observability
 

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -1,0 +1,206 @@
+# VAC GUI Redesign Roadmap
+
+> Status: implementation branch kickoff. This document defines the GUI redesign direction for v2: VAC GUI moves from a feature-tab control panel to a resident runtime cockpit plus Flowgraph Studio.
+
+---
+
+## 0. Goal
+
+VAC v2 is an always-on dataflow application. The GUI should therefore answer the user's first question immediately:
+
+```text
+What is VAC doing right now, what needs attention, and what can I safely change?
+```
+
+The current GUI exposes useful surfaces, but its top-level structure still reflects a feature bucket model:
+
+- Live
+- Setup
+- Flowgraph
+- Logs
+- Tools
+
+The v2 GUI will use an operational model instead:
+
+- Now
+- Modes
+- Flowgraph Studio
+- Resources
+- Observability
+- Settings
+
+This is a breaking information-architecture change. Existing lower-level panels should be reused where they still fit, but the top-level shell should be rebuilt around runtime state.
+
+---
+
+## 1. Principles
+
+### 1.1 Now-first
+
+The first screen is `Now`, not setup and not the editor. A resident app must show current state before configuration.
+
+`Now` aggregates:
+
+- WebSocket / Control API connection state
+- current runtime mode
+- AI persona state
+- Flowgraph load health
+- Managed App state
+- recent important events
+
+### 1.2 Modes are first-class
+
+Runtime Mode is a primary user workflow. The GUI must make mode switching visible and reversible enough to trust.
+
+Initial UI can show planned mode concepts before the backend lands, but the final UI must support:
+
+- current mode indicator
+- transition dry-run preview
+- transition request
+- transition progress / result
+- per-mode Flowgraph / Managed App summary
+
+### 1.3 Flowgraph Studio is an IDE surface
+
+The Flowgraph editor should feel like a compact IDE:
+
+- file tree
+- canvas
+- command palette
+- searchable node insert
+- inspector
+- problems panel
+- undo / redo
+- multi-select
+- grouping / alignment
+
+The initial branch does not implement all of this. It changes the top-level IA first so later PRs have a stable target.
+
+### 1.4 Resources are external runtime dependencies
+
+Managed Apps, OAuth, OBS / Warudo / TTS, and future integrations belong under `Resources`. They are not general settings; they are runtime dependencies VAC can start, stop, authorize, or inspect.
+
+### 1.5 Observability is separate from editing
+
+Logs, event timeline, Flowgraph diagnostics, and runtime history are operational observation surfaces. They should not be hidden behind editor panels.
+
+---
+
+## 2. Target Navigation
+
+### 2.1 Now
+
+Operational dashboard. Shows current state and recent runtime activity.
+
+### 2.2 Modes
+
+Runtime mode management. This is wired to the Runtime Mode roadmap when the backend lands.
+
+### 2.3 Flowgraph Studio
+
+Flowgraph authoring and debugging. Existing `FlowgraphTab` is renamed conceptually first; deep editor refactors happen in later PRs.
+
+### 2.4 Resources
+
+External dependencies and credentials:
+
+- Managed Apps
+- OAuth
+- run_with registry
+- OBS / avatar / TTS integrations
+
+Existing `SetupTab` content can move here in stages.
+
+### 2.5 Observability
+
+Runtime observation:
+
+- logs
+- event stream
+- diagnostics
+- transition results
+
+Existing `LogsTab` is the first implementation.
+
+### 2.6 Settings
+
+Configuration and dangerous operations:
+
+- profile management
+- restart / shutdown
+- reload
+- developer tools
+
+Existing `ToolsTab` can remain here until split further.
+
+---
+
+## 3. Implementation Plan
+
+### GR-1 Shell IA
+
+- Replace top-level tab list with `Now / Modes / Flowgraph Studio / Resources / Observability / Settings`.
+- Keep old hash redirects:
+  - `#live` -> `#now`
+  - `#setup` -> `#resources`
+  - `#logs` -> `#observability`
+  - `#tools` -> `#settings`
+  - `#pipeline` -> `#flowgraph`
+- Add `NowTab`.
+- Add `ModesTab` placeholder that is explicit about unavailable backend state without inventing fake control.
+
+### GR-2 Now Dashboard
+
+- Aggregate existing endpoints only:
+  - `/snapshot`
+  - `/managed_apps`
+  - `/flowgraph/tree`
+  - `/flowgraph/diagnostics`
+  - Control WS event buffer
+- Do not add backend API in this PR.
+
+### GR-3 Resource Re-home
+
+- Move OAuth, reload, pause, profile, and run_with panels into the new IA.
+- Split operational resources from restart / destructive settings.
+
+### GR-4 Flowgraph Studio Layout
+
+- Replace fixed 3-pane layout with a resizable editor shell.
+- Rename property editor role to Inspector.
+- Move diagnostics into a Problems panel.
+- Add command palette and node search as primary node insertion path.
+
+### GR-5 Editor Operations
+
+- Undo / redo stack.
+- Multi-select as a real data model.
+- Group / align / duplicate / delete commands.
+- E2E coverage for keyboard and mouse editing.
+
+### GR-6 Runtime Modes UI
+
+- Wire to Runtime Mode backend.
+- Add dry-run transition plan preview.
+- Display Flowgraph activation and Managed App desired-state changes.
+
+### GR-7 Observability
+
+- Event timeline with filters.
+- Flowgraph execution history.
+- Runtime mode transition history.
+- Managed App event history.
+
+---
+
+## 4. First Branch Scope
+
+The first GUI branch implements only GR-1 and the first slice of GR-2:
+
+- new top-level navigation ids and labels
+- `NowTab` based on existing APIs
+- `ModesTab` placeholder
+- smoke test update
+
+No Flowgraph editor internals are changed in this slice.
+

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -1,6 +1,6 @@
 # VAC GUI Redesign Roadmap
 
-> Status: implementation branch active. The first cockpit shell, Runtime Mode surface, Flowgraph Studio framing, Resource / Settings split, Observability surface, and Playwright coverage are now implemented on the GUI branch. Remaining work is mainly deeper editor operations and backend-backed history surfaces.
+> Status: implementation branch active. The cockpit shell, Runtime Mode surface, Flowgraph Studio operations, Resource / Settings split, Observability history surfaces, transition progress UX, and Playwright coverage are now implemented on the GUI branch. Remaining work is refinement: visual polish, deeper domain-specific debugger views, and future backend integrations that are not yet specified.
 
 ---
 
@@ -190,7 +190,7 @@ Existing `ToolsTab` can remain here until split further.
 - [x] Request transitions via `/modes/transit`.
 - [x] Display Flowgraph activation and Managed App desired-state changes from the backend plan.
 - [x] Keep planned mode previews visible, but enable transition only for modes present in `conf [modes]`.
-- [ ] Add richer transition-progress UX if the backend later exposes long-running progress states.
+- [x] Add transition-progress UX backed by `/modes/transition` server-side progress state.
 
 ### GR-7 Observability - implemented first slice
 
@@ -213,6 +213,7 @@ The current GUI branch now includes these completed slices:
 - GR-4 Flowgraph Studio framing, resizable panes, and searchable command palette / node insert
 - GR-5 editor operation commands: undo / redo, multi-select, group-layout, align, distribute, duplicate, delete
 - GR-6 Runtime Mode backend wiring, dry-run preview, transit action, and desired-state display
+- GR-6 Runtime Mode transition progress API and UX
 - GR-7 Observability over snapshot + event stream + server-side event history
 - Playwright regression coverage for shell navigation, Now, Modes, Flowgraph Studio, and Observability
 

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -163,6 +163,9 @@ Existing `ToolsTab` can remain here until split further.
 
 - Move OAuth, reload, pause, profile, and run_with panels into the new IA.
 - Split operational resources from restart / destructive settings.
+- Initial split:
+  - `Resources`: run_with / Managed App registry, Pause / Resume, OAuth, future OBS / avatar / TTS connectors.
+  - `Settings`: profile management, reload, Control API connection info, developer utilities.
 
 ### GR-4 Flowgraph Studio Layout
 
@@ -203,4 +206,3 @@ The first GUI branch implements only GR-1 and the first slice of GR-2:
 - smoke test update
 
 No Flowgraph editor internals are changed in this slice.
-

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -1,6 +1,6 @@
 # VAC GUI Redesign Roadmap
 
-> Status: implementation branch kickoff. This document defines the GUI redesign direction for v2: VAC GUI moves from a feature-tab control panel to a resident runtime cockpit plus Flowgraph Studio.
+> Status: implementation branch active. The first cockpit shell, Runtime Mode surface, Flowgraph Studio framing, Resource / Settings split, Observability surface, and Playwright coverage are now implemented on the GUI branch. Remaining work is mainly deeper editor operations and backend-backed history surfaces.
 
 ---
 
@@ -137,79 +137,81 @@ Existing `ToolsTab` can remain here until split further.
 
 ## 3. Implementation Plan
 
-### GR-1 Shell IA
+### GR-1 Shell IA - implemented
 
-- Replace top-level tab list with `Now / Modes / Flowgraph Studio / Resources / Observability / Settings`.
-- Use a responsive navigation shell: horizontal on narrow screens, left rail on desktop.
-- Keep old hash redirects:
+- [x] Replace top-level tab list with `Now / Modes / Flowgraph Studio / Resources / Observability / Settings`.
+- [x] Use a responsive navigation shell: horizontal on narrow screens, left rail on desktop.
+- [x] Keep old hash redirects:
   - `#live` -> `#now`
   - `#setup` -> `#resources`
   - `#logs` -> `#observability`
   - `#tools` -> `#settings`
   - `#pipeline` -> `#flowgraph`
-- Add `NowTab`.
-- Add `ModesTab` placeholder that is explicit about unavailable backend state without inventing fake control.
+- [x] Add `NowTab`.
+- [x] Add `ModesTab`.
 
-### GR-2 Now Dashboard
+### GR-2 Now Dashboard - implemented first slice
 
-- Aggregate existing endpoints only:
+- [x] Aggregate existing endpoints only:
   - `/snapshot`
   - `/modes/current`
   - `/managed_apps`
   - `/flowgraph/tree`
   - `/flowgraph/diagnostics`
   - Control WS event buffer
-- Do not add backend API in this PR.
+- [x] Do not add backend API in this PR.
 
-### GR-3 Resource Re-home
+### GR-3 Resource Re-home - implemented first slice
 
-- Move OAuth, reload, pause, profile, and run_with panels into the new IA.
-- Split operational resources from restart / destructive settings.
-- Initial split:
+- [x] Move OAuth, reload, pause, profile, and run_with panels into the new IA.
+- [x] Split operational resources from restart / destructive settings.
+- [x] Initial split:
   - `Resources`: run_with / Managed App registry, Pause / Resume, OAuth, future OBS / avatar / TTS connectors.
   - `Settings`: profile management, reload, Control API connection info, developer utilities.
 
-### GR-4 Flowgraph Studio Layout
+### GR-4 Flowgraph Studio Layout - implemented first and second slices
 
-- Replace fixed 3-pane layout with a resizable editor shell.
-- Rename property editor role to Inspector.
-- Move diagnostics into a Problems panel.
-- Add command palette and node search as primary node insertion path.
-- First slice: add a Studio heading, file / node / edge summary, named workspace regions, Inspector label, and Problems panel while keeping the existing editor behavior intact.
-- Second slice: add a command palette entry point that groups existing Flowgraph operations before deeper editor command modeling lands.
+- [x] Add a Studio heading, file / node / edge summary, named workspace regions, Inspector label, and Problems panel while keeping the existing editor behavior intact.
+- [x] Add a command palette entry point that groups existing Flowgraph operations before deeper editor command modeling lands.
+- [ ] Replace the current framed editor shell with true resizable panes.
+- [ ] Add searchable node insert backed by command modeling.
 
 ### GR-5 Editor Operations
 
-- Undo / redo stack.
-- Multi-select as a real data model.
-- Group / align / duplicate / delete commands.
-- E2E coverage for keyboard and mouse editing.
+- [ ] Undo / redo stack.
+- [ ] Multi-select as a real data model.
+- [ ] Group / align / duplicate / delete commands.
+- [ ] E2E coverage for keyboard and mouse editing.
 
-### GR-6 Runtime Modes UI
+### GR-6 Runtime Modes UI - implemented backend wiring
 
-- Wire to Runtime Mode backend.
-- Add dry-run transition plan preview.
-- Display Flowgraph activation and Managed App desired-state changes.
-- Before backend support, keep the Modes surface read-only: planned mode cards, static transition preview, and disabled transition action only.
-- After v2 Runtime Mode backend landed, connect Modes to `/modes` and `/modes/current`; keep planned mode previews visible, but enable transition only for modes present in `conf [modes]`.
+- [x] Wire to Runtime Mode backend.
+- [x] Add dry-run transition plan preview via `/modes/plan`.
+- [x] Request transitions via `/modes/transit`.
+- [x] Display Flowgraph activation and Managed App desired-state changes from the backend plan.
+- [x] Keep planned mode previews visible, but enable transition only for modes present in `conf [modes]`.
+- [ ] Add richer transition-progress UX if the backend later exposes long-running progress states.
 
-### GR-7 Observability
+### GR-7 Observability - implemented first slice
 
-- Event timeline with filters.
-- Flowgraph execution history.
-- Runtime mode transition history.
-- Managed App event history.
-- First slice: expose Observability as an explicit evidence surface around the existing runtime snapshot and event stream before adding new backend history APIs.
+- [x] Expose Observability as an explicit evidence surface around the existing runtime snapshot and event stream.
+- [x] Event timeline with filters for current ControlEvent kinds, including Runtime Mode events.
+- [ ] Flowgraph execution history.
+- [ ] Runtime mode transition history.
+- [ ] Managed App event history.
 
 ---
 
-## 4. First Branch Scope
+## 4. Current Branch Scope
 
-The first GUI branch implements only GR-1 and the first slice of GR-2:
+The current GUI branch now includes these completed slices:
 
-- new top-level navigation ids and labels
-- `NowTab` based on existing APIs
-- `ModesTab` placeholder
-- smoke test update
+- GR-1 shell IA and legacy hash fallback
+- GR-2 Now dashboard using existing Control API endpoints
+- GR-3 Resources / Settings split for operational vs durable controls
+- GR-4 Flowgraph Studio framing plus command palette entry point
+- GR-6 Runtime Mode backend wiring, dry-run preview, transit action, and desired-state display
+- GR-7 Observability first slice over snapshot + event stream
+- Playwright regression coverage for shell navigation, Now, Modes, Flowgraph Studio, and Observability
 
-No Flowgraph editor internals are changed in this slice.
+The next substantial GUI work should start with GR-5 editor operations or with backend-backed history APIs for GR-7. Both are larger than the shell/cockpit work and should be split into separate implementation branches if possible.

--- a/docs/roadmap/gui-redesign-roadmap.md
+++ b/docs/roadmap/gui-redesign-roadmap.md
@@ -187,6 +187,7 @@ Existing `ToolsTab` can remain here until split further.
 - Wire to Runtime Mode backend.
 - Add dry-run transition plan preview.
 - Display Flowgraph activation and Managed App desired-state changes.
+- Before backend support, keep the Modes surface read-only: planned mode cards, static transition preview, and disabled transition action only.
 
 ### GR-7 Observability
 

--- a/gui/src/App.svelte
+++ b/gui/src/App.svelte
@@ -22,10 +22,10 @@
 
  import NowTab from './lib/tabs/NowTab.svelte';
  import ModesTab from './lib/tabs/ModesTab.svelte';
- import SetupTab from './lib/tabs/SetupTab.svelte';
+ import ResourcesTab from './lib/tabs/ResourcesTab.svelte';
+ import SettingsTab from './lib/tabs/SettingsTab.svelte';
  import FlowgraphTab from './lib/tabs/FlowgraphTab.svelte';
  import LogsTab from './lib/tabs/LogsTab.svelte';
- import ToolsTab from './lib/tabs/ToolsTab.svelte';
 
  import { tabNavStore } from './lib/tabs.svelte';
  import { api } from './lib/api';
@@ -114,11 +114,11 @@ async function handleShutdownClick() {
   {:else if tabNavStore.active === 'flowgraph'}
    <FlowgraphTab />
   {:else if tabNavStore.active === 'resources'}
-   <SetupTab />
+   <ResourcesTab />
   {:else if tabNavStore.active === 'observability'}
    <LogsTab />
   {:else if tabNavStore.active === 'settings'}
-   <ToolsTab />
+   <SettingsTab />
   {/if}
  </main>
 

--- a/gui/src/App.svelte
+++ b/gui/src/App.svelte
@@ -3,7 +3,7 @@
   * Phase VI-γ-1: アプリケーションシェル。
   *
   * - 上部ヘッダ（ロゴ / 接続インジケータ / 再起動ボタン）
-  * - タブナビゲーション（Live / Setup / Flowgraph / Logs / Tools）
+  * - タブナビゲーション（Now / Modes / Flowgraph Studio / Resources / Observability / Settings）
   * - 下部ステータスバー（常駐）
   * - 右下トーストレイヤ
   * - 再起動・プロファイル切替モーダル
@@ -20,7 +20,8 @@
  import RestartDialog from './lib/RestartDialog.svelte';
  import ManagedAppDrawer from './lib/ManagedAppDrawer.svelte';
 
- import LiveTab from './lib/tabs/LiveTab.svelte';
+ import NowTab from './lib/tabs/NowTab.svelte';
+ import ModesTab from './lib/tabs/ModesTab.svelte';
  import SetupTab from './lib/tabs/SetupTab.svelte';
  import FlowgraphTab from './lib/tabs/FlowgraphTab.svelte';
  import LogsTab from './lib/tabs/LogsTab.svelte';
@@ -106,15 +107,17 @@ async function handleShutdownClick() {
  </header>
 
  <main class="flex-1 px-6 py-4">
-  {#if tabNavStore.active === 'live'}
-   <LiveTab />
-  {:else if tabNavStore.active === 'setup'}
-   <SetupTab />
+  {#if tabNavStore.active === 'now'}
+   <NowTab />
+  {:else if tabNavStore.active === 'modes'}
+   <ModesTab />
   {:else if tabNavStore.active === 'flowgraph'}
    <FlowgraphTab />
-  {:else if tabNavStore.active === 'logs'}
+  {:else if tabNavStore.active === 'resources'}
+   <SetupTab />
+  {:else if tabNavStore.active === 'observability'}
    <LogsTab />
-  {:else if tabNavStore.active === 'tools'}
+  {:else if tabNavStore.active === 'settings'}
    <ToolsTab />
   {/if}
  </main>

--- a/gui/src/App.svelte
+++ b/gui/src/App.svelte
@@ -3,7 +3,7 @@
   * Phase VI-γ-1: アプリケーションシェル。
   *
   * - 上部ヘッダ（ロゴ / 接続インジケータ / 再起動ボタン）
-  * - タブナビゲーション（Now / Modes / Flowgraph Studio / Resources / Observability / Settings）
+  * - 左ナビゲーション（Now / Modes / Flowgraph Studio / Resources / Observability / Settings）
   * - 下部ステータスバー（常駐）
   * - 右下トーストレイヤ
   * - 再起動・プロファイル切替モーダル
@@ -63,16 +63,14 @@ async function handleShutdownClick() {
 </script>
 
 <div class="flex min-h-screen flex-col bg-surface-50-950 text-surface-950-50">
- <header
-  class="sticky top-0 z-20 border-b border-surface-200-800 bg-surface-50-950/95 backdrop-blur"
- >
+ <header class="sticky top-0 z-20 border-b border-surface-200-800 bg-surface-50-950/95 backdrop-blur">
   <div class="flex items-center justify-between gap-3 px-6 py-2">
    <div class="flex items-baseline gap-3">
     <h1 class="text-lg font-bold">
      Virtual Avatar Connect
-     <span class="text-primary-500">Control Panel</span>
+     <span class="text-primary-500">Runtime Cockpit</span>
     </h1>
-    <span class="text-xs opacity-60">Phase VI-γ-1</span>
+    <span class="text-xs opacity-60">v2 GUI redesign</span>
    </div>
    <div class="flex items-center gap-2">
     <ConnectionBadge />
@@ -103,24 +101,29 @@ async function handleShutdownClick() {
     </button>
    </div>
   </div>
-  <TabNav />
  </header>
 
- <main class="flex-1 px-6 py-4">
-  {#if tabNavStore.active === 'now'}
-   <NowTab />
-  {:else if tabNavStore.active === 'modes'}
-   <ModesTab />
-  {:else if tabNavStore.active === 'flowgraph'}
-   <FlowgraphTab />
-  {:else if tabNavStore.active === 'resources'}
-   <ResourcesTab />
-  {:else if tabNavStore.active === 'observability'}
-   <LogsTab />
-  {:else if tabNavStore.active === 'settings'}
-   <SettingsTab />
-  {/if}
- </main>
+ <div class="grid flex-1 min-h-0 lg:grid-cols-[240px_minmax(0,1fr)]">
+  <aside class="border-b border-surface-200-800 bg-surface-100-900/60 lg:border-b-0 lg:border-r">
+   <TabNav />
+  </aside>
+
+  <main class="min-w-0 flex-1 px-4 py-4 lg:px-6">
+   {#if tabNavStore.active === 'now'}
+    <NowTab />
+   {:else if tabNavStore.active === 'modes'}
+    <ModesTab />
+   {:else if tabNavStore.active === 'flowgraph'}
+    <FlowgraphTab />
+   {:else if tabNavStore.active === 'resources'}
+    <ResourcesTab />
+   {:else if tabNavStore.active === 'observability'}
+    <LogsTab />
+   {:else if tabNavStore.active === 'settings'}
+    <SettingsTab />
+   {/if}
+  </main>
+ </div>
 
  <StatusBar />
 </div>

--- a/gui/src/lib/EventHistoryPanel.svelte
+++ b/gui/src/lib/EventHistoryPanel.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+ import { onMount } from 'svelte';
+ import { api } from './api';
+ import type { ControlEvent, ControlEventHistoryItem, ControlEventKind } from './types';
+
+ type HistoryScope = 'all' | 'flowgraph' | 'runtime_mode' | 'managed_app';
+
+ let loading = $state(false);
+ let error = $state<string | null>(null);
+ let events = $state<ControlEventHistoryItem[]>([]);
+ let scope = $state<HistoryScope>('all');
+
+ const kindByScope: Record<Exclude<HistoryScope, 'all'>, ControlEventKind[]> = {
+  flowgraph: ['flowgraph_reloaded', 'restart_recommended'],
+  runtime_mode: ['runtime_mode_changed', 'runtime_mode_managed_apps'],
+  managed_app: ['managed_app_state', 'runtime_mode_managed_apps'],
+ };
+
+ const filtered = $derived.by(() => {
+  if (scope === 'all') return events;
+  const kinds = new Set(kindByScope[scope]);
+  return events.filter((item) => kinds.has(item.event.kind));
+ });
+
+ async function load(): Promise<void> {
+  loading = true;
+  error = null;
+  try {
+   const res = await api.eventHistory(200);
+   events = res.events;
+  } catch (e) {
+   error = e instanceof Error ? e.message : String(e);
+  } finally {
+   loading = false;
+  }
+ }
+
+ function summarize(ev: ControlEvent): string {
+  switch (ev.kind) {
+   case 'flowgraph_reloaded':
+    return `${ev.ok ? 'ok' : 'issues'} nodes=${ev.node_count} errors=${ev.error_count} warnings=${ev.warning_count}`;
+   case 'restart_recommended':
+    return ev.reason;
+   case 'runtime_mode_changed':
+    return `${ev.previous_effective_id || '(none)'} -> ${ev.current_effective_id || '(none)'}`;
+   case 'runtime_mode_managed_apps':
+    return ev.ops.map((op) => `${op.op}:${op.id}:${op.ok ? 'ok' : 'failed'}`).join(', ') || 'no ops';
+   case 'managed_app_state':
+    return `${ev.id} ${ev.running ? 'running' : 'stopped'} pids=[${ev.pids.join(',')}]`;
+   case 'pause_state':
+    return `${ev.target} ${ev.paused ? 'paused' : 'resumed'}`;
+   case 'reloaded':
+    return `${ev.target}${ev.id ? `:${ev.id}` : ''}`;
+   case 'processor_invoked':
+    return `${ev.feature} ${ev.outcome} ${ev.elapsed_ms}ms`;
+   case 'channel_datum':
+    return `${ev.phase} #${ev.id} ${ev.channel}`;
+   case 'oauth_status':
+    return `${ev.account} ${ev.status}`;
+   case 'restarting':
+    return `pid=${ev.new_pid} graceful=${ev.graceful_ms}ms`;
+   case 'heartbeat':
+    return ev.now;
+   case 'lagged':
+    return `dropped ${ev.dropped}`;
+  }
+ }
+
+ onMount(() => {
+  void load();
+ });
+</script>
+
+<section class="rounded border border-surface-200-800 bg-surface-50-950">
+ <div class="flex flex-wrap items-center justify-between gap-2 border-b border-surface-200-800 px-3 py-2">
+  <div>
+   <h3 class="text-sm font-semibold">Event History</h3>
+   <p class="text-xs opacity-60">Server-side ring buffer for operational evidence.</p>
+  </div>
+  <div class="flex items-center gap-2">
+   <select class="rounded border border-surface-300-700 bg-surface-50-950 px-2 py-1 text-xs" bind:value={scope}>
+    <option value="all">All</option>
+    <option value="flowgraph">Flowgraph</option>
+    <option value="runtime_mode">Runtime Mode</option>
+    <option value="managed_app">Managed Apps</option>
+   </select>
+   <button
+    type="button"
+    class="rounded border border-surface-300-700 px-2 py-1 text-xs hover:bg-surface-100-900 disabled:opacity-50"
+    disabled={loading}
+    onclick={() => void load()}
+   >
+    {loading ? 'Loading...' : 'Refresh'}
+   </button>
+  </div>
+ </div>
+
+ {#if error}
+  <div class="px-3 py-3 text-sm text-error-500">{error}</div>
+ {:else if filtered.length === 0}
+  <div class="px-3 py-6 text-center text-sm opacity-60">No event history yet.</div>
+ {:else}
+  <ol class="max-h-72 overflow-y-auto">
+   {#each filtered.toReversed() as item}
+    <li class="border-b border-surface-200-800 px-3 py-2 last:border-b-0">
+     <div class="flex items-center gap-2 text-[11px] opacity-60">
+      <span>{new Date(item.at).toLocaleString()}</span>
+      <code>{item.event.kind}</code>
+     </div>
+     <div class="mt-1 font-mono text-xs break-all">{summarize(item.event)}</div>
+    </li>
+   {/each}
+  </ol>
+ {/if}
+</section>

--- a/gui/src/lib/EventStream.svelte
+++ b/gui/src/lib/EventStream.svelte
@@ -35,6 +35,9 @@ let filter: FilterMap = $state({
  managed_app_state: true,
  // Phase δ-6: Flowgraph ホットリロード通知。編集中はあったほうが便利なのでデフォルト ON。
  flowgraph_reloaded: true,
+ restart_recommended: true,
+ runtime_mode_changed: true,
+ runtime_mode_managed_apps: true,
 });
 
  let paused: boolean = $state(false);
@@ -88,6 +91,12 @@ let filter: FilterMap = $state({
    return `${ev.id} ${ev.running ? 'RUNNING' : 'STOPPED'} pids=[${ev.pids.join(',')}]`;
   case 'flowgraph_reloaded':
    return `${ev.root_dir} ok=${ev.ok} nodes=${ev.node_count} (err=${ev.error_count} warn=${ev.warning_count})`;
+  case 'restart_recommended':
+   return `${ev.reason}: ${JSON.stringify(ev.details)}`;
+  case 'runtime_mode_changed':
+   return `${ev.previous_effective_id || '(none)'} → ${ev.current_effective_id || '(none)'}${ev.reason ? ` (${ev.reason})` : ''}`;
+  case 'runtime_mode_managed_apps':
+   return `${ev.previous_effective_id} → ${ev.current_effective_id}: ${ev.ops.map((op) => `${op.op}:${op.id}:${op.ok ? 'ok' : 'fail'}`).join(', ')}`;
   default:
    return assertNever(ev);
  }
@@ -116,6 +125,12 @@ let filter: FilterMap = $state({
    return 'bg-tertiary-200-800 text-tertiary-900-100';
   case 'flowgraph_reloaded':
    return 'bg-success-200-800 text-success-900-100';
+  case 'restart_recommended':
+   return 'bg-warning-200-800 text-warning-900-100';
+  case 'runtime_mode_changed':
+   return 'bg-primary-200-800 text-primary-900-100';
+  case 'runtime_mode_managed_apps':
+   return 'bg-tertiary-200-800 text-tertiary-900-100';
   default:
    return assertNever(k);
  }
@@ -146,6 +161,9 @@ const ALL_KINDS: readonly ControlEventKind[] = [
  'oauth_status',
  'restarting',
  'managed_app_state',
+ 'runtime_mode_changed',
+ 'runtime_mode_managed_apps',
+ 'restart_recommended',
  'flowgraph_reloaded',
  'heartbeat',
  'lagged',

--- a/gui/src/lib/TabNav.svelte
+++ b/gui/src/lib/TabNav.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
  /**
-  * タブナビゲーションの表示。現在タブは URL hash (`#live`, `#pipeline`, ...) で保持し、
+  * タブナビゲーションの表示。現在タブは URL hash (`#now`, `#flowgraph`, ...) で保持し、
   * ブラウザ戻る/進むや deep-link に対応する。
   *
-  * γ-1 ではシンプルな水平タブ。γ-7 でアイコンや色を整えていく。
+  * GUI redesign 初期段階では水平タブを維持し、情報設計だけ先に v2 へ寄せる。
   */
  import { tabNavStore, type TabId, TABS } from './tabs.svelte';
 

--- a/gui/src/lib/TabNav.svelte
+++ b/gui/src/lib/TabNav.svelte
@@ -3,7 +3,7 @@
   * タブナビゲーションの表示。現在タブは URL hash (`#now`, `#flowgraph`, ...) で保持し、
   * ブラウザ戻る/進むや deep-link に対応する。
   *
-  * GUI redesign 初期段階では水平タブを維持し、情報設計だけ先に v2 へ寄せる。
+  * GUI redesign では desktop を左レール、mobile を横スクロールにする。
   */
  import { tabNavStore, type TabId, TABS } from './tabs.svelte';
 
@@ -13,18 +13,20 @@
 </script>
 
 <nav
- class="flex items-center gap-1 border-b border-surface-200-800 px-6"
+ class="flex items-center gap-1 overflow-x-auto px-4 py-2 lg:flex-col lg:items-stretch lg:overflow-visible lg:px-3 lg:py-4"
  aria-label="Main tabs"
 >
  {#each TABS as tab (tab.id)}
   {@const active = tabNavStore.active === tab.id}
   <button
    type="button"
-   class="relative px-4 py-2.5 text-sm transition-colors"
+   class="relative rounded px-4 py-2.5 text-left text-sm transition-colors lg:w-full"
    class:font-semibold={active}
    class:text-primary-500={active}
    class:text-surface-700-300={!active}
+   class:bg-surface-50-950={active}
    class:hover:text-surface-950-50={!active}
+   class:hover:bg-surface-50-950={!active}
    aria-current={active ? 'page' : undefined}
    onclick={() => onClick(tab.id)}
   >
@@ -33,7 +35,7 @@
     <span>{tab.label}</span>
    </span>
    {#if active}
-    <span class="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-primary-500"></span>
+    <span class="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-primary-500 lg:inset-x-0 lg:inset-y-2 lg:h-auto lg:w-0.5"></span>
    {/if}
   </button>
  {/each}

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -50,6 +50,9 @@ import {
  type ProfilesResponse,
  type ReloadRequest,
  type ReloadResponse,
+ type CurrentModeResponse,
+ type ModesListResponse,
+ type PutCurrentModeBody,
  type RestartRequest,
  type RestartResponse,
  type ShutdownRequest,
@@ -178,6 +181,17 @@ export const api = {
    method: 'POST',
    body: { target: 'modify_files', id } satisfies ReloadRequest,
   });
+ },
+
+ // --- Runtime Modes ---
+ modesList(): Promise<ModesListResponse> {
+  return request<ModesListResponse>('/modes');
+ },
+ currentMode(): Promise<CurrentModeResponse> {
+  return request<CurrentModeResponse>('/modes/current');
+ },
+ putCurrentMode(req: PutCurrentModeBody): Promise<CurrentModeResponse> {
+  return request<CurrentModeResponse>('/modes/current', { method: 'PUT', body: req });
  },
 
  // --- OAuth (Twitch DCF) ---

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -51,6 +51,7 @@ import {
  type ReloadRequest,
  type ReloadResponse,
  type CurrentModeResponse,
+ type ControlEventHistoryResponse,
  type ModePlanRequest,
  type ModeTransitRequest,
  type ModeTransitResponse,
@@ -160,6 +161,11 @@ export const api = {
  // --- Snapshot ---
  snapshot(): Promise<StateSnapshot> {
   return request<StateSnapshot>('/snapshot');
+ },
+ eventHistory(limit = 100, kind?: string): Promise<ControlEventHistoryResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (kind) params.set('kind', kind);
+  return request<ControlEventHistoryResponse>(`/events/history?${params.toString()}`);
  },
 
  // --- Pause / Resume ---

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -51,6 +51,10 @@ import {
  type ReloadRequest,
  type ReloadResponse,
  type CurrentModeResponse,
+ type ModePlanRequest,
+ type ModeTransitRequest,
+ type ModeTransitResponse,
+ type ModeTransitionPlan,
  type ModesListResponse,
  type PutCurrentModeBody,
  type RestartRequest,
@@ -192,6 +196,12 @@ export const api = {
  },
  putCurrentMode(req: PutCurrentModeBody): Promise<CurrentModeResponse> {
   return request<CurrentModeResponse>('/modes/current', { method: 'PUT', body: req });
+ },
+ modePlan(req: ModePlanRequest): Promise<ModeTransitionPlan> {
+  return request<ModeTransitionPlan>('/modes/plan', { method: 'POST', body: req });
+ },
+ modeTransit(req: ModeTransitRequest): Promise<ModeTransitResponse> {
+  return request<ModeTransitResponse>('/modes/transit', { method: 'POST', body: req });
  },
 
  // --- OAuth (Twitch DCF) ---

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -58,6 +58,7 @@ import {
  type ModeTransitionPlan,
  type ModesListResponse,
  type PutCurrentModeBody,
+ type RuntimeModeTransitionStatus,
  type RestartRequest,
  type RestartResponse,
  type ShutdownRequest,
@@ -208,6 +209,9 @@ export const api = {
  },
  modeTransit(req: ModeTransitRequest): Promise<ModeTransitResponse> {
   return request<ModeTransitResponse>('/modes/transit', { method: 'POST', body: req });
+ },
+ modeTransition(): Promise<RuntimeModeTransitionStatus> {
+  return request<RuntimeModeTransitionStatus>('/modes/transition');
  },
 
  // --- OAuth (Twitch DCF) ---

--- a/gui/src/lib/flowgraph/FlowgraphCanvas.svelte
+++ b/gui/src/lib/flowgraph/FlowgraphCanvas.svelte
@@ -77,7 +77,7 @@
      feature: n.feature,
      spec,
     },
-    selected: flowgraphStore.selectedNodeId === n.id,
+    selected: flowgraphStore.selectedNodeIds.includes(n.id) || flowgraphStore.selectedNodeId === n.id,
    };
   });
  }
@@ -192,7 +192,8 @@
  }
 
  function onSelectionChange(params: { nodes: Node[]; edges: Edge[] }) {
-  const firstNode = params.nodes[0];
+ const firstNode = params.nodes[0];
+  flowgraphStore.selectedNodeIds = params.nodes.map((n) => n.id);
   flowgraphStore.selectedNodeId = firstNode ? firstNode.id : null;
  }
 

--- a/gui/src/lib/flowgraphStore.svelte.ts
+++ b/gui/src/lib/flowgraphStore.svelte.ts
@@ -68,6 +68,10 @@ class FlowgraphStore {
 
  /** いま選択しているキャンバス上のノード ID。プロパティエディタが参照する。 */
  selectedNodeId: string | null = $state(null);
+ /** 複数選択中のノード ID。先頭は Inspector が扱う primary selection。 */
+ selectedNodeIds: string[] = $state([]);
+ undoStack: FlowgraphHistoryEntry[] = $state([]);
+ redoStack: FlowgraphHistoryEntry[] = $state([]);
 
  /** 保存中 / 削除中 / 新規作成中のスピナー用。同時に複数走らない前提。 */
  mutating: boolean = $state(false);
@@ -124,6 +128,7 @@ class FlowgraphStore {
   this.currentState = 'loading';
   this.currentError = null;
   this.selectedNodeId = null;
+  this.selectedNodeIds = [];
   try {
    const resp = await api.flowgraphFile(fq);
    this.currentFile = resp;
@@ -137,6 +142,8 @@ class FlowgraphStore {
       }))
     : null;
    this.draftEdges = resp.parsed ? resp.parsed.edges.map((e) => ({ from: e.from, to: e.to })) : null;
+   this.undoStack = [];
+   this.redoStack = [];
    this.currentState = 'ok';
   } catch (e) {
    this.currentState = 'error';
@@ -152,6 +159,9 @@ class FlowgraphStore {
   this.draftNodes = null;
   this.draftEdges = null;
   this.selectedNodeId = null;
+  this.selectedNodeIds = [];
+  this.undoStack = [];
+  this.redoStack = [];
   this.currentState = 'idle';
   this.currentError = null;
  }
@@ -159,18 +169,21 @@ class FlowgraphStore {
  /** draft 層のノード位置を更新する。Svelte Flow から呼ぶ。 */
  updateNodePosition(id: string, x: number, y: number): void {
   if (!this.draftNodes) return;
+  this.#pushHistory('Move node');
   const next = this.draftNodes.map((n) => (n.id === id ? { ...n, position: [x, y] as [number, number] } : n));
   this.draftNodes = next;
  }
 
  updateNodeProperty(id: string, key: string, value: unknown): void {
   if (!this.draftNodes) return;
+  this.#pushHistory('Edit property');
   const next = this.draftNodes.map((n) => (n.id === id ? { ...n, properties: { ...n.properties, [key]: value } } : n));
   this.draftNodes = next;
  }
 
  removeNodeProperty(id: string, key: string): void {
   if (!this.draftNodes) return;
+  this.#pushHistory('Remove property');
   const next = this.draftNodes.map((n) => {
    if (n.id !== id) return n;
    const props = { ...n.properties };
@@ -182,6 +195,7 @@ class FlowgraphStore {
 
  addNode(node: FlowgraphDraftNode): void {
   if (!this.draftNodes) this.draftNodes = [];
+  this.#pushHistory('Add node');
   this.draftNodes = [...this.draftNodes, node];
  }
 
@@ -206,24 +220,98 @@ class FlowgraphStore {
   };
   this.addNode(node);
   this.selectedNodeId = node.id;
+  this.selectedNodeIds = [node.id];
   return true;
  }
 
  /** Phase ο-6: 選択中ノードを (+24,+24) オフセットで複製（エッジはコピーしない）。 */
  duplicateSelectedNode(): boolean {
-  if (!this.selectedNodeId || !this.draftNodes) return false;
-  const src = this.draftNodes.find((n) => n.id === this.selectedNodeId);
-  if (!src) return false;
-  const id = this.#makeUniqueNodeId(src.feature, this.draftNodes);
-  const basePos = src.position ?? [100, 100];
-  const dup: FlowgraphDraftNode = {
-   id,
-   feature: src.feature,
-   position: [Math.round(basePos[0] + 24), Math.round(basePos[1] + 24)],
-   properties: { ...src.properties },
-  };
-  this.addNode(dup);
-  this.selectedNodeId = dup.id;
+  const ids = this.selectedNodeIds.length > 0 ? this.selectedNodeIds : this.selectedNodeId ? [this.selectedNodeId] : [];
+  return this.duplicateNodes(ids);
+ }
+
+ duplicateNodes(ids: string[]): boolean {
+  if (!this.draftNodes || ids.length === 0) return false;
+  const sourceIds = new Set(ids);
+  const sources = this.draftNodes.filter((n) => sourceIds.has(n.id));
+  if (sources.length === 0) return false;
+  this.#pushHistory(sources.length > 1 ? 'Duplicate nodes' : 'Duplicate node');
+  let nextNodes = [...this.draftNodes];
+  const duplicatedIds: string[] = [];
+  for (const src of sources) {
+   const id = this.#makeUniqueNodeId(src.feature, nextNodes);
+   const basePos = src.position ?? [100, 100];
+   const dup: FlowgraphDraftNode = {
+    id,
+    feature: src.feature,
+    position: [Math.round(basePos[0] + 24), Math.round(basePos[1] + 24)],
+    properties: { ...src.properties },
+   };
+   nextNodes = [...nextNodes, dup];
+   duplicatedIds.push(id);
+  }
+  this.draftNodes = nextNodes;
+  this.selectedNodeIds = duplicatedIds;
+  this.selectedNodeId = duplicatedIds[0] ?? null;
+  return true;
+ }
+
+ alignSelectedNodes(axis: 'x' | 'y'): boolean {
+  if (!this.draftNodes || this.selectedNodeIds.length < 2) return false;
+  const selected = new Set(this.selectedNodeIds);
+  const anchor = this.draftNodes.find((n) => selected.has(n.id))?.position ?? [100, 100];
+  this.#pushHistory(axis === 'x' ? 'Align vertical' : 'Align horizontal');
+  this.draftNodes = this.draftNodes.map((n) => {
+   if (!selected.has(n.id)) return n;
+   const pos = n.position ?? [100, 100];
+   return { ...n, position: axis === 'x' ? [anchor[0], pos[1]] : [pos[0], anchor[1]] };
+  });
+  return true;
+ }
+
+ distributeSelectedNodes(axis: 'x' | 'y'): boolean {
+  if (!this.draftNodes || this.selectedNodeIds.length < 3) return false;
+  const selected = new Set(this.selectedNodeIds);
+  const rows = this.draftNodes
+   .filter((n) => selected.has(n.id))
+   .map((n) => ({ id: n.id, position: n.position ?? ([100, 100] as [number, number]) }))
+   .sort((a, b) => (axis === 'x' ? a.position[0] - b.position[0] : a.position[1] - b.position[1]));
+  if (rows.length < 3) return false;
+  this.#pushHistory(axis === 'x' ? 'Distribute horizontal' : 'Distribute vertical');
+  const first = rows[0].position;
+  const last = rows[rows.length - 1].position;
+  const step = (axis === 'x' ? last[0] - first[0] : last[1] - first[1]) / (rows.length - 1);
+  const positions = new Map<string, [number, number]>();
+  rows.forEach((row, i) => {
+   positions.set(
+    row.id,
+    axis === 'x'
+     ? [Math.round(first[0] + step * i), row.position[1]]
+     : [row.position[0], Math.round(first[1] + step * i)],
+   );
+  });
+  this.draftNodes = this.draftNodes.map((n) => {
+   const pos = positions.get(n.id);
+   return pos ? { ...n, position: pos } : n;
+  });
+  return true;
+ }
+
+ groupSelectedNodes(): boolean {
+  if (!this.draftNodes || this.selectedNodeIds.length < 2) return false;
+  const selected = new Set(this.selectedNodeIds);
+  this.#pushHistory('Group nodes');
+  const rows = this.draftNodes.filter((n) => selected.has(n.id));
+  const positions = rows.map((n) => n.position ?? ([100, 100] as [number, number]));
+  const minX = Math.min(...positions.map((p) => p[0]));
+  const minY = Math.min(...positions.map((p) => p[1]));
+  this.draftNodes = this.draftNodes.map((n) => {
+   if (!selected.has(n.id)) return n;
+   const rowIndex = rows.findIndex((r) => r.id === n.id);
+   const col = rowIndex % 2;
+   const row = Math.floor(rowIndex / 2);
+   return { ...n, position: [Math.round(minX + col * 220), Math.round(minY + row * 150)] };
+  });
   return true;
  }
 
@@ -266,11 +354,13 @@ class FlowgraphStore {
 
  removeNode(id: string): void {
   if (!this.draftNodes) return;
+  this.#pushHistory('Remove node');
   this.draftNodes = this.draftNodes.filter((n) => n.id !== id);
   if (this.draftEdges) {
    this.draftEdges = this.draftEdges.filter((e) => !edgeMentionsNode(e, id));
   }
   if (this.selectedNodeId === id) this.selectedNodeId = null;
+  this.selectedNodeIds = this.selectedNodeIds.filter((selected) => selected !== id);
  }
 
  /**
@@ -293,6 +383,7 @@ class FlowgraphStore {
   if (removedNodes.length === 0 && removedEdges.length === 0) {
    return { removedNodes: 0, removedEdges: 0 };
   }
+  this.#pushHistory('Delete selection');
 
   this.#lastDeletion = {
    nodes: removedNodes.map((n) => ({
@@ -309,6 +400,7 @@ class FlowgraphStore {
    (e) => !edgeKeys.has(`${e.from}||${e.to}`) && !edgeMentionsAny(e, nodeSet),
   );
   if (this.selectedNodeId && nodeSet.has(this.selectedNodeId)) this.selectedNodeId = null;
+  this.selectedNodeIds = this.selectedNodeIds.filter((id) => !nodeSet.has(id));
 
   return { removedNodes: removedNodes.length, removedEdges: removedEdges.length };
  }
@@ -331,6 +423,34 @@ class FlowgraphStore {
  /** γ-4a.0: 直前の削除があるか（UI の undo ボタン表示判定に使う）。 */
  hasPendingUndo(): boolean {
   return this.#lastDeletion !== null;
+ }
+
+ canUndo(): boolean {
+  return this.undoStack.length > 0;
+ }
+
+ canRedo(): boolean {
+  return this.redoStack.length > 0;
+ }
+
+ undo(): boolean {
+  if (this.undoStack.length === 0) return false;
+  const current = this.#snapshot('Redo point');
+  const entry = this.undoStack[this.undoStack.length - 1];
+  this.undoStack = this.undoStack.slice(0, -1);
+  this.redoStack = [...this.redoStack, current].slice(-50);
+  this.#restoreSnapshot(entry);
+  return true;
+ }
+
+ redo(): boolean {
+  if (this.redoStack.length === 0) return false;
+  const current = this.#snapshot('Undo point');
+  const entry = this.redoStack[this.redoStack.length - 1];
+  this.redoStack = this.redoStack.slice(0, -1);
+  this.undoStack = [...this.undoStack, current].slice(-50);
+  this.#restoreSnapshot(entry);
+  return true;
  }
 
  /**
@@ -363,14 +483,40 @@ class FlowgraphStore {
   edges: FlowgraphDraftEdge[];
  } | null = null;
 
+ #pushHistory(label: string): void {
+  if (!this.draftNodes || !this.draftEdges) return;
+  this.undoStack = [...this.undoStack, this.#snapshot(label)].slice(-50);
+  this.redoStack = [];
+ }
+
+ #snapshot(label: string): FlowgraphHistoryEntry {
+  return {
+   label,
+   nodes: cloneNodes(this.draftNodes ?? []),
+   edges: cloneEdges(this.draftEdges ?? []),
+   selectedNodeIds: [...this.selectedNodeIds],
+   selectedNodeId: this.selectedNodeId,
+  };
+ }
+
+ #restoreSnapshot(entry: FlowgraphHistoryEntry): void {
+  this.draftNodes = cloneNodes(entry.nodes);
+  this.draftEdges = cloneEdges(entry.edges);
+  this.selectedNodeIds = [...entry.selectedNodeIds];
+  this.selectedNodeId = entry.selectedNodeId;
+  this.#lastDeletion = null;
+ }
+
  addEdge(from: string, to: string): void {
   if (!this.draftEdges) this.draftEdges = [];
   if (this.draftEdges.some((e) => e.from === from && e.to === to)) return;
+  this.#pushHistory('Connect edge');
   this.draftEdges = [...this.draftEdges, { from, to }];
  }
 
  removeEdge(from: string, to: string): void {
   if (!this.draftEdges) return;
+  this.#pushHistory('Remove edge');
   this.draftEdges = this.draftEdges.filter((e) => !(e.from === from && e.to === to));
  }
 
@@ -716,6 +862,27 @@ export type FlowgraphDraftEdge = {
  from: string;
  to: string;
 };
+
+type FlowgraphHistoryEntry = {
+ label: string;
+ nodes: FlowgraphDraftNode[];
+ edges: FlowgraphDraftEdge[];
+ selectedNodeIds: string[];
+ selectedNodeId: string | null;
+};
+
+function cloneNodes(nodes: FlowgraphDraftNode[]): FlowgraphDraftNode[] {
+ return nodes.map((n) => ({
+  id: n.id,
+  feature: n.feature,
+  position: n.position ? [n.position[0], n.position[1]] : null,
+  properties: { ...n.properties },
+ }));
+}
+
+function cloneEdges(edges: FlowgraphDraftEdge[]): FlowgraphDraftEdge[] {
+ return edges.map((e) => ({ from: e.from, to: e.to }));
+}
 
 function edgeMentionsNode(edge: FlowgraphDraftEdge, nodeId: string): boolean {
  return parsePortRef(edge.from).nodeId === nodeId || parsePortRef(edge.to).nodeId === nodeId;

--- a/gui/src/lib/tabs.svelte.ts
+++ b/gui/src/lib/tabs.svelte.ts
@@ -1,7 +1,7 @@
 /**
  * Phase VI-γ-1: トップレベルのタブ構成。
  *
- * - 5 タブ固定: Live / Setup / Flowgraph / Logs / Tools
+ * - v2 GUI: Now / Modes / Flowgraph Studio / Resources / Observability / Settings
  * - URL hash (`#live` 等) で永続化。ブラウザ戻る/進むと同期。
  * - シングルトンストアで全コンポーネントに共有。
  *
@@ -9,14 +9,16 @@
  * 既存パネル群は Tools タブに仮配置し、表示経路を壊さないようにする。
  *
  * δ-9 D.5: V1 `Pipeline` タブは廃止。旧 `#pipeline` URL は `flowgraph` に fallback する。
+ * GUI redesign: 旧 `#live` / `#setup` / `#logs` / `#tools` は新 IA の対応タブへ fallback する。
  */
 
 export const TABS = [
- { id: 'live', label: 'Live', icon: 'L' },
- { id: 'setup', label: 'Setup', icon: 'S' },
- { id: 'flowgraph', label: 'Flowgraph', icon: 'F' },
- { id: 'logs', label: 'Logs', icon: 'G' },
- { id: 'tools', label: 'Tools', icon: 'T' },
+ { id: 'now', label: 'Now', icon: 'N' },
+ { id: 'modes', label: 'Modes', icon: 'M' },
+ { id: 'flowgraph', label: 'Flowgraph Studio', icon: 'F' },
+ { id: 'resources', label: 'Resources', icon: 'R' },
+ { id: 'observability', label: 'Observability', icon: 'O' },
+ { id: 'settings', label: 'Settings', icon: 'S' },
 ] as const;
 
 export type TabId = (typeof TABS)[number]['id'];
@@ -24,11 +26,14 @@ export type TabId = (typeof TABS)[number]['id'];
 const VALID_IDS: readonly TabId[] = TABS.map((t) => t.id);
 
 function fromHash(): TabId {
- if (typeof window === 'undefined') return 'live';
+ if (typeof window === 'undefined') return 'now';
  const h = window.location.hash.replace(/^#/, '').trim().toLowerCase();
- // δ-9 D.5: 旧 `#pipeline` をブックマークしていた既存ユーザー向けの fallback。
+ if (h === 'live') return 'now';
+ if (h === 'setup') return 'resources';
+ if (h === 'logs') return 'observability';
+ if (h === 'tools') return 'settings';
  if (h === 'pipeline') return 'flowgraph';
- return (VALID_IDS as readonly string[]).includes(h) ? (h as TabId) : 'live';
+ return (VALID_IDS as readonly string[]).includes(h) ? (h as TabId) : 'now';
 }
 
 class TabNavStore {

--- a/gui/src/lib/tabs/FlowgraphTab.svelte
+++ b/gui/src/lib/tabs/FlowgraphTab.svelte
@@ -80,6 +80,9 @@ onMount(() => {
  const summary = $derived(summarizeDiagnostics(flowgraphStore.diagnostics?.diagnostics));
  const hasErrors = $derived(summary.error > 0);
  const hasWarnings = $derived(summary.warning > 0);
+ const fileCount = $derived(flowgraphStore.tree?.files.length ?? 0);
+ const nodeCount = $derived(flowgraphStore.draftNodes?.length ?? 0);
+ const edgeCount = $derived(flowgraphStore.draftEdges?.length ?? 0);
 
  async function onReload() {
   await flowgraphStore.reloadFromDisk();
@@ -129,7 +132,28 @@ function onImportZip() {
 }
 </script>
 
-<div class="flex h-[calc(100vh-9rem)] flex-col gap-2">
+<div class="flex h-[calc(100vh-9rem)] min-h-[42rem] flex-col gap-3">
+ <div class="flex flex-wrap items-start justify-between gap-3">
+  <div>
+   <h2 class="text-xl font-semibold">Flowgraph Studio</h2>
+   <p class="text-sm opacity-65">Author, inspect, and repair runtime dataflow files.</p>
+  </div>
+  <div class="grid grid-cols-3 overflow-hidden rounded border border-surface-200-800 bg-surface-50-950 text-center text-xs">
+   <div class="border-r border-surface-200-800 px-3 py-2">
+    <div class="font-semibold">{fileCount}</div>
+    <div class="opacity-60">Files</div>
+   </div>
+   <div class="border-r border-surface-200-800 px-3 py-2">
+    <div class="font-semibold">{nodeCount}</div>
+    <div class="opacity-60">Nodes</div>
+   </div>
+   <div class="px-3 py-2">
+    <div class="font-semibold">{edgeCount}</div>
+    <div class="opacity-60">Edges</div>
+   </div>
+  </div>
+ </div>
+
  <!-- Toolbar -->
  <div class="flex flex-wrap items-center gap-2 rounded border border-surface-200-800 bg-surface-100-900 px-3 py-2">
   <div class="flex items-baseline gap-2">
@@ -219,26 +243,52 @@ function onImportZip() {
 
 <FlowgraphShareDialog bind:open={dialogOpen} bind:mode={dialogMode} />
 
- <!-- Main 3-pane -->
- <div class="grid flex-1 min-h-0 gap-2" style="grid-template-columns: 260px minmax(0, 1fr) 320px;">
-  <div class="min-h-0 overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950">
-   <FlowgraphTree />
-  </div>
-  <div class="min-h-0 overflow-hidden rounded border border-surface-200-800 bg-surface-50-950">
-   <FlowgraphCanvas />
-  </div>
-  <div class="flex min-h-0 flex-col gap-2">
-   <div class="flex-1 min-h-0 overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950">
-    <FlowgraphPalette />
+ <!-- Studio workspace -->
+ <div class="grid min-h-0 flex-1 gap-2 xl:grid-cols-[260px_minmax(34rem,1fr)_320px]">
+  <section class="flex min-h-[16rem] flex-col overflow-hidden rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="border-b border-surface-200-800 px-3 py-2 text-xs font-semibold uppercase tracking-wider opacity-60">
+    Files
    </div>
-   <div class="flex-1 min-h-0 overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950">
-    <FlowgraphPropertyEditor />
+   <div class="min-h-0 flex-1 overflow-y-auto">
+    <FlowgraphTree />
    </div>
+  </section>
+
+  <section class="flex min-h-[28rem] flex-col overflow-hidden rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="flex items-center justify-between gap-2 border-b border-surface-200-800 px-3 py-2">
+    <span class="text-xs font-semibold uppercase tracking-wider opacity-60">Canvas</span>
+    <span class="truncate text-xs opacity-60">{flowgraphStore.currentFq ?? 'No file selected'}</span>
+   </div>
+   <div class="min-h-0 flex-1 overflow-hidden">
+    <FlowgraphCanvas />
+   </div>
+  </section>
+
+  <div class="grid min-h-[28rem] grid-rows-[minmax(12rem,1fr)_minmax(12rem,1fr)] gap-2">
+   <section class="flex min-h-0 flex-col overflow-hidden rounded border border-surface-200-800 bg-surface-50-950">
+    <div class="border-b border-surface-200-800 px-3 py-2 text-xs font-semibold uppercase tracking-wider opacity-60">
+     Node Palette
+    </div>
+    <div class="min-h-0 flex-1 overflow-hidden">
+     <FlowgraphPalette />
+    </div>
+   </section>
+   <section class="flex min-h-0 flex-col overflow-hidden rounded border border-surface-200-800 bg-surface-50-950">
+    <div class="border-b border-surface-200-800 px-3 py-2 text-xs font-semibold uppercase tracking-wider opacity-60">
+     Inspector
+    </div>
+    <div class="min-h-0 flex-1 overflow-y-auto">
+     <FlowgraphPropertyEditor />
+    </div>
+   </section>
   </div>
  </div>
 
- <!-- Diagnostics -->
- <div class="max-h-40 overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950">
+ <!-- Problems -->
+ <section class="max-h-44 overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950">
+  <div class="border-b border-surface-200-800 px-3 py-2 text-xs font-semibold uppercase tracking-wider opacity-60">
+   Problems
+  </div>
   <FlowgraphDiagnostics />
- </div>
+ </section>
 </div>

--- a/gui/src/lib/tabs/FlowgraphTab.svelte
+++ b/gui/src/lib/tabs/FlowgraphTab.svelte
@@ -29,6 +29,10 @@
 let dialogOpen = $state(false);
 let dialogMode = $state<'paste' | 'import_zip'>('paste');
 let commandPaletteOpen = $state(false);
+let commandQuery = $state('');
+let filePaneWidth = $state(260);
+let inspectorPaneWidth = $state(320);
+let problemsHeight = $state(176);
 
 type StudioCommand = {
  id: string;
@@ -51,6 +55,21 @@ onMount(() => {
     if (!flowgraphStore.currentFq || flowgraphStore.mutating) return;
     ev.preventDefault();
     void flowgraphStore.saveCurrent();
+    return;
+   }
+
+   const isUndo = (ev.ctrlKey || ev.metaKey) && !ev.altKey && ev.key.toLowerCase() === 'z';
+   if (isUndo) {
+    ev.preventDefault();
+    if (ev.shiftKey) onRedo();
+    else onUndo();
+    return;
+   }
+
+   const isRedo = (ev.ctrlKey || ev.metaKey) && !ev.shiftKey && !ev.altKey && ev.key.toLowerCase() === 'y';
+   if (isRedo) {
+    ev.preventDefault();
+    onRedo();
     return;
    }
 
@@ -100,7 +119,67 @@ onMount(() => {
  const fileCount = $derived(flowgraphStore.tree?.files.length ?? 0);
  const nodeCount = $derived(flowgraphStore.draftNodes?.length ?? 0);
  const edgeCount = $derived(flowgraphStore.draftEdges?.length ?? 0);
+ const workspaceGridStyle = $derived(
+  `grid-template-columns: ${filePaneWidth}px minmax(34rem, 1fr) ${inspectorPaneWidth}px;`,
+ );
+ const problemsStyle = $derived(`max-height: ${problemsHeight}px;`);
  const studioCommands: StudioCommand[] = $derived([
+  {
+   id: 'undo',
+   label: 'Undo',
+   description: 'Revert the last canvas edit.',
+   disabled: !flowgraphStore.canUndo(),
+   run: onUndo,
+  },
+  {
+   id: 'redo',
+   label: 'Redo',
+   description: 'Reapply the last reverted canvas edit.',
+   disabled: !flowgraphStore.canRedo(),
+   run: onRedo,
+  },
+  {
+   id: 'duplicate',
+   label: 'Duplicate selection',
+   description: 'Duplicate the selected node or node set.',
+   disabled: !flowgraphStore.currentFq || flowgraphStore.selectedNodeIds.length === 0,
+   run: onDuplicateSelection,
+  },
+  {
+   id: 'align_horizontal',
+   label: 'Align horizontal',
+   description: 'Align selected nodes to the same y position.',
+   disabled: flowgraphStore.selectedNodeIds.length < 2,
+   run: () => flowgraphStore.alignSelectedNodes('y'),
+  },
+  {
+   id: 'align_vertical',
+   label: 'Align vertical',
+   description: 'Align selected nodes to the same x position.',
+   disabled: flowgraphStore.selectedNodeIds.length < 2,
+   run: () => flowgraphStore.alignSelectedNodes('x'),
+  },
+  {
+   id: 'distribute_horizontal',
+   label: 'Distribute horizontal',
+   description: 'Evenly space selected nodes along the x axis.',
+   disabled: flowgraphStore.selectedNodeIds.length < 3,
+   run: () => flowgraphStore.distributeSelectedNodes('x'),
+  },
+  {
+   id: 'distribute_vertical',
+   label: 'Distribute vertical',
+   description: 'Evenly space selected nodes along the y axis.',
+   disabled: flowgraphStore.selectedNodeIds.length < 3,
+   run: () => flowgraphStore.distributeSelectedNodes('y'),
+  },
+  {
+   id: 'group_layout',
+   label: 'Group layout',
+   description: 'Pack selected nodes into a compact visual group without adding source metadata.',
+   disabled: flowgraphStore.selectedNodeIds.length < 2,
+   run: () => flowgraphStore.groupSelectedNodes(),
+  },
   {
    id: 'reload',
    label: 'Reload from disk',
@@ -150,7 +229,42 @@ onMount(() => {
    disabled: false,
    run: onImportZip,
   },
+  ...nodeInsertCommands(),
  ]);
+
+ const filteredStudioCommands = $derived.by(() => {
+  const q = commandQuery.trim().toLowerCase();
+  if (!q) return studioCommands;
+  return studioCommands.filter((command) =>
+   `${command.label} ${command.description}`.toLowerCase().includes(q),
+  );
+ });
+
+ function nodeInsertCommands(): StudioCommand[] {
+  const specs = flowgraphStore.catalog?.specs ?? [];
+  return specs.slice(0, 250).map((spec) => ({
+   id: `insert:${spec.feature}`,
+   label: `Insert ${spec.title}`,
+   description: `${spec.category} · ${spec.feature}`,
+   disabled: !flowgraphStore.currentFq,
+   run: () => {
+    flowgraphStore.addCatalogNodeAt(spec, null);
+   },
+  }));
+ }
+
+ function onUndo() {
+  if (flowgraphStore.undo()) toastStore.info('Undo', flowgraphStore.undoStack.at(-1)?.label ?? '');
+ }
+
+ function onRedo() {
+  if (flowgraphStore.redo()) toastStore.info('Redo', flowgraphStore.redoStack.at(-1)?.label ?? '');
+ }
+
+ function onDuplicateSelection() {
+  const ok = flowgraphStore.duplicateSelectedNode();
+  if (ok) toastStore.success('Duplicated', `${flowgraphStore.selectedNodeIds.length} node(s)`);
+ }
 
  async function onReload() {
   await flowgraphStore.reloadFromDisk();
@@ -257,6 +371,18 @@ async function runStudioCommand(command: StudioCommand) {
   >
    {summary.error}E / {summary.warning}W / {summary.info}I
   </span>
+  <label class="flex items-center gap-1 text-[10px] opacity-70" title="Resize file pane">
+   Files
+   <input class="w-20" type="range" min="200" max="420" step="10" bind:value={filePaneWidth} />
+  </label>
+  <label class="flex items-center gap-1 text-[10px] opacity-70" title="Resize inspector pane">
+   Side pane
+   <input class="w-20" type="range" min="260" max="520" step="10" bind:value={inspectorPaneWidth} />
+  </label>
+  <label class="flex items-center gap-1 text-[10px] opacity-70" title="Resize problems panel">
+   Bottom pane
+   <input class="w-20" type="range" min="120" max="360" step="8" bind:value={problemsHeight} />
+  </label>
   <button
    type="button"
    class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800"
@@ -355,8 +481,15 @@ async function runStudioCommand(command: StudioCommand) {
      Close
     </button>
    </div>
+   <div class="border-b border-surface-200-800 px-3 py-2">
+    <input
+     class="w-full rounded border border-surface-300-700 bg-surface-50-950 px-3 py-2 text-sm"
+     placeholder="Search commands or node catalog"
+     bind:value={commandQuery}
+    />
+   </div>
    <div class="grid gap-1 p-2">
-    {#each studioCommands as command (command.id)}
+    {#each filteredStudioCommands as command (command.id)}
      <button
       type="button"
       class="rounded px-3 py-2 text-left hover:bg-surface-100-900 disabled:opacity-40 disabled:hover:bg-transparent"
@@ -366,14 +499,16 @@ async function runStudioCommand(command: StudioCommand) {
       <div class="text-sm font-semibold">{command.label}</div>
       <div class="mt-0.5 text-xs opacity-60">{command.description}</div>
      </button>
-   {/each}
+    {:else}
+     <div class="px-3 py-8 text-center text-sm opacity-60">No matching command.</div>
+    {/each}
    </div>
   </div>
  </div>
 {/if}
 
  <!-- Studio workspace -->
- <div class="grid min-h-0 flex-1 gap-2 xl:grid-cols-[260px_minmax(34rem,1fr)_320px]">
+ <div class="grid min-h-0 flex-1 gap-2 xl:grid-cols-[260px_minmax(34rem,1fr)_320px]" style={workspaceGridStyle}>
   <section class="flex min-h-[16rem] flex-col overflow-hidden rounded border border-surface-200-800 bg-surface-50-950">
    <div class="border-b border-surface-200-800 px-3 py-2 text-xs font-semibold uppercase tracking-wider opacity-60">
     Files
@@ -414,7 +549,7 @@ async function runStudioCommand(command: StudioCommand) {
  </div>
 
  <!-- Problems -->
- <section class="max-h-44 overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950">
+ <section class="overflow-y-auto rounded border border-surface-200-800 bg-surface-50-950" style={problemsStyle}>
   <div class="border-b border-surface-200-800 px-3 py-2 text-xs font-semibold uppercase tracking-wider opacity-60">
    Problems
   </div>

--- a/gui/src/lib/tabs/FlowgraphTab.svelte
+++ b/gui/src/lib/tabs/FlowgraphTab.svelte
@@ -28,6 +28,15 @@
 
 let dialogOpen = $state(false);
 let dialogMode = $state<'paste' | 'import_zip'>('paste');
+let commandPaletteOpen = $state(false);
+
+type StudioCommand = {
+ id: string;
+ label: string;
+ description: string;
+ disabled: boolean;
+ run: () => void | Promise<void>;
+};
 
 onMount(() => {
   void flowgraphStore.refreshAll();
@@ -42,6 +51,14 @@ onMount(() => {
     if (!flowgraphStore.currentFq || flowgraphStore.mutating) return;
     ev.preventDefault();
     void flowgraphStore.saveCurrent();
+    return;
+   }
+
+   const isCommandPalette =
+    (ev.ctrlKey || ev.metaKey) && !ev.shiftKey && !ev.altKey && ev.key.toLowerCase() === 'k';
+   if (isCommandPalette) {
+    ev.preventDefault();
+    commandPaletteOpen = true;
     return;
    }
 
@@ -83,6 +100,57 @@ onMount(() => {
  const fileCount = $derived(flowgraphStore.tree?.files.length ?? 0);
  const nodeCount = $derived(flowgraphStore.draftNodes?.length ?? 0);
  const edgeCount = $derived(flowgraphStore.draftEdges?.length ?? 0);
+ const studioCommands: StudioCommand[] = $derived([
+  {
+   id: 'reload',
+   label: 'Reload from disk',
+   description: 'Refresh Flowgraph files and diagnostics from the configured root.',
+   disabled: flowgraphStore.mutating,
+   run: onReload,
+  },
+  {
+   id: 'save',
+   label: 'Save current file',
+   description: 'Write the current Flowgraph file to disk.',
+   disabled: !flowgraphStore.currentFq || flowgraphStore.mutating,
+   run: onSave,
+  },
+  {
+   id: 'open_external',
+   label: 'Open external editor',
+   description: 'Open the selected Flowgraph file in an external editor.',
+   disabled: !flowgraphStore.currentFq,
+   run: onOpenExternal,
+  },
+  {
+   id: 'copy_fragment',
+   label: 'Copy fragment',
+   description: 'Copy the selected node, or the current file when no node is selected.',
+   disabled: !flowgraphStore.currentFq,
+   run: onCopy,
+  },
+  {
+   id: 'paste_fragment',
+   label: 'Paste fragment',
+   description: 'Open the fragment paste dialog.',
+   disabled: false,
+   run: onPaste,
+  },
+  {
+   id: 'export_zip',
+   label: 'Export ZIP',
+   description: 'Export the current Flowgraph file as a ZIP fragment.',
+   disabled: !flowgraphStore.currentFq,
+   run: onExportZip,
+  },
+  {
+   id: 'import_zip',
+   label: 'Import ZIP',
+   description: 'Open the ZIP import preview dialog.',
+   disabled: false,
+   run: onImportZip,
+  },
+ ]);
 
  async function onReload() {
   await flowgraphStore.reloadFromDisk();
@@ -130,6 +198,12 @@ function onImportZip() {
  dialogMode = 'import_zip';
  dialogOpen = true;
 }
+
+async function runStudioCommand(command: StudioCommand) {
+ if (command.disabled) return;
+ commandPaletteOpen = false;
+ await command.run();
+}
 </script>
 
 <div class="flex h-[calc(100vh-9rem)] min-h-[42rem] flex-col gap-3">
@@ -166,6 +240,14 @@ function onImportZip() {
    </span>
   </div>
   <div class="flex-1"></div>
+  <button
+   type="button"
+   class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800"
+   title="Open command palette (Ctrl+K)"
+   onclick={() => (commandPaletteOpen = true)}
+  >
+   Commands
+  </button>
   <span
    class="rounded px-2 py-0.5 text-xs"
    class:bg-error-500={hasErrors}
@@ -242,6 +324,53 @@ function onImportZip() {
 </div>
 
 <FlowgraphShareDialog bind:open={dialogOpen} bind:mode={dialogMode} />
+
+{#if commandPaletteOpen}
+ <div
+  class="fixed inset-0 z-50 flex items-start justify-center bg-black/35 px-4 py-20"
+  role="presentation"
+  onclick={() => (commandPaletteOpen = false)}
+ >
+  <div
+   class="w-full max-w-xl overflow-hidden rounded border border-surface-300-700 bg-surface-50-950 shadow-xl"
+   role="dialog"
+   aria-modal="true"
+   aria-labelledby="flowgraph-command-palette-title"
+   tabindex="-1"
+   onkeydown={(ev) => {
+    if (ev.key === 'Escape') commandPaletteOpen = false;
+   }}
+   onclick={(ev) => ev.stopPropagation()}
+  >
+   <div class="flex items-center justify-between border-b border-surface-200-800 px-4 py-3">
+    <div>
+     <h3 id="flowgraph-command-palette-title" class="text-sm font-semibold">Command Palette</h3>
+     <p class="text-xs opacity-60">Flowgraph Studio operations</p>
+    </div>
+    <button
+     type="button"
+     class="rounded border border-surface-300-700 px-2 py-1 text-xs hover:bg-surface-200-800"
+     onclick={() => (commandPaletteOpen = false)}
+    >
+     Close
+    </button>
+   </div>
+   <div class="grid gap-1 p-2">
+    {#each studioCommands as command (command.id)}
+     <button
+      type="button"
+      class="rounded px-3 py-2 text-left hover:bg-surface-100-900 disabled:opacity-40 disabled:hover:bg-transparent"
+      disabled={command.disabled}
+      onclick={() => void runStudioCommand(command)}
+     >
+      <div class="text-sm font-semibold">{command.label}</div>
+      <div class="mt-0.5 text-xs opacity-60">{command.description}</div>
+     </button>
+   {/each}
+   </div>
+  </div>
+ </div>
+{/if}
 
  <!-- Studio workspace -->
  <div class="grid min-h-0 flex-1 gap-2 xl:grid-cols-[260px_minmax(34rem,1fr)_320px]">

--- a/gui/src/lib/tabs/LogsTab.svelte
+++ b/gui/src/lib/tabs/LogsTab.svelte
@@ -8,7 +8,34 @@
  import SnapshotView from '../SnapshotView.svelte';
 </script>
 
-<div class="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
- <SnapshotView />
- <EventStream />
+<section class="grid gap-4">
+ <div class="flex flex-wrap items-start justify-between gap-3">
+  <div>
+   <h2 class="text-xl font-semibold">Observability</h2>
+   <p class="text-sm opacity-65">Runtime snapshot, live event timeline, and operational evidence.</p>
+  </div>
+  <div class="grid grid-cols-3 overflow-hidden rounded border border-surface-200-800 bg-surface-50-950 text-center text-xs">
+   <div class="border-r border-surface-200-800 px-3 py-2">
+    <div class="font-semibold">Snapshot</div>
+    <div class="opacity-60">state</div>
+   </div>
+   <div class="border-r border-surface-200-800 px-3 py-2">
+    <div class="font-semibold">Timeline</div>
+    <div class="opacity-60">events</div>
+   </div>
+   <div class="px-3 py-2">
+    <div class="font-semibold">Filters</div>
+    <div class="opacity-60">kinds</div>
+   </div>
+  </div>
 </div>
+
+ <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(26rem,0.92fr)_minmax(28rem,1.08fr)]">
+  <div class="min-w-0">
+   <SnapshotView />
+  </div>
+  <div class="min-w-0">
+   <EventStream />
+  </div>
+ </div>
+</section>

--- a/gui/src/lib/tabs/LogsTab.svelte
+++ b/gui/src/lib/tabs/LogsTab.svelte
@@ -5,6 +5,7 @@
   * 既存の EventStream + SnapshotView をそのまま並べ、γ-5 で高度フィルタ・ダウンロード・全文検索へ拡張する。
   */
  import EventStream from '../EventStream.svelte';
+ import EventHistoryPanel from '../EventHistoryPanel.svelte';
  import SnapshotView from '../SnapshotView.svelte';
 </script>
 
@@ -34,8 +35,11 @@
   <div class="min-w-0">
    <SnapshotView />
   </div>
-  <div class="min-w-0">
-   <EventStream />
+ <div class="min-w-0">
+   <div class="grid gap-4">
+    <EventStream />
+    <EventHistoryPanel />
+   </div>
   </div>
  </div>
 </section>

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
  import { onMount } from 'svelte';
  import { api } from '../api';
- import { ControlApiError, type ModeTransitionPlan, type RuntimeModeManagedAppOp } from '../types';
+ import {
+  ControlApiError,
+  type ModeTransitionPlan,
+  type RuntimeModeManagedAppOp,
+  type RuntimeModeTransitionStatus,
+ } from '../types';
 
  type PlannedMode = {
   id: string;
@@ -69,6 +74,7 @@
  let planLoading = $state(false);
  let planError = $state<string | null>(null);
  let transitionPlan = $state<ModeTransitionPlan | null>(null);
+ let transitionStatus = $state<RuntimeModeTransitionStatus | null>(null);
  let managedAppOps = $state<RuntimeModeManagedAppOp[]>([]);
  let planRequestSeq = 0;
 
@@ -94,10 +100,22 @@
  const managedDesiredRows = $derived(managedDirectiveRows(transitionPlan));
  const selectedCanTransit = $derived(selectedMode?.configured === true);
  const isCurrentSelected = $derived(selectedMode?.id === currentModeId);
+ const transitionPercent = $derived.by(() => {
+  if (!transitionStatus || transitionStatus.step_count <= 0) return 0;
+  return Math.min(100, Math.round((transitionStatus.step_index / transitionStatus.step_count) * 100));
+ });
  const transitDisabled = $derived(
-  loading || mutating || planLoading || loadError !== null || !selectedMode || !selectedCanTransit || isCurrentSelected,
+  loading ||
+   mutating ||
+   transitionStatus?.active === true ||
+   planLoading ||
+   loadError !== null ||
+   !selectedMode ||
+   !selectedCanTransit ||
+   isCurrentSelected,
  );
  const transitLabel = $derived.by(() => {
+  if (transitionStatus?.active) return 'Transition running...';
   if (mutating) return 'Transiting...';
   if (planLoading) return 'Planning...';
   if (loadError) return 'Transit unavailable';
@@ -108,6 +126,11 @@
 
  onMount(() => {
   void refreshModes();
+  void refreshTransitionStatus();
+  const timer = window.setInterval(() => {
+   void refreshTransitionStatus();
+  }, 1200);
+  return () => window.clearInterval(timer);
  });
 
  $effect(() => {
@@ -162,10 +185,24 @@
    currentModeId = next.mode;
    transitionPlan = next.plan;
    managedAppOps = next.managed_apps ?? [];
+   await refreshTransitionStatus();
   } catch (e) {
    mutationError = formatError(e);
   } finally {
    mutating = false;
+  }
+ }
+
+ async function refreshTransitionStatus(): Promise<void> {
+  try {
+   const status = await api.modeTransition();
+   transitionStatus = status;
+   if (!status.active && status.phase === 'completed') {
+    if (status.plan) transitionPlan = status.plan;
+    if (status.managed_apps.length > 0) managedAppOps = status.managed_apps;
+   }
+  } catch {
+   // The main Runtime Mode API status already reports backend availability.
   }
  }
 
@@ -241,6 +278,31 @@
   <div class="rounded border border-error-500 bg-error-100-900 px-4 py-3 text-sm text-error-900-100">
    Runtime Mode transition failed: {mutationError}
   </div>
+ {/if}
+ {#if transitionStatus && transitionStatus.phase !== 'idle'}
+  <section class="rounded border border-surface-200-800 bg-surface-50-950 px-4 py-3">
+   <div class="flex flex-wrap items-center justify-between gap-2">
+    <div>
+     <div class="text-sm font-semibold">Transition Progress</div>
+     <div class="mt-1 text-xs opacity-65">
+      {transitionStatus.message}
+      <span class="ml-2 font-mono">{transitionStatus.phase}</span>
+     </div>
+    </div>
+    <div class="text-xs opacity-65">
+     step {transitionStatus.step_index}/{transitionStatus.step_count}
+    </div>
+   </div>
+   <div class="mt-3 h-2 overflow-hidden rounded bg-surface-200-800">
+    <div
+     class="h-full {transitionStatus.phase === 'failed' ? 'bg-error-500' : 'bg-primary-500'}"
+     style={`width: ${transitionPercent}%`}
+    ></div>
+   </div>
+   {#if transitionStatus.error}
+    <div class="mt-2 text-xs text-error-500">{transitionStatus.error}</div>
+   {/if}
+  </section>
  {/if}
 
  <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
  import { onMount } from 'svelte';
  import { api } from '../api';
- import { ControlApiError } from '../types';
+ import { ControlApiError, type ModeTransitionPlan, type RuntimeModeManagedAppOp } from '../types';
 
  type PlannedMode = {
   id: string;
@@ -66,6 +66,11 @@
  let loadError = $state<string | null>(null);
  let mutating = $state(false);
  let mutationError = $state<string | null>(null);
+ let planLoading = $state(false);
+ let planError = $state<string | null>(null);
+ let transitionPlan = $state<ModeTransitionPlan | null>(null);
+ let managedAppOps = $state<RuntimeModeManagedAppOp[]>([]);
+ let planRequestSeq = 0;
 
  const displayModes = $derived.by<DisplayMode[]>(() => {
   const configured = new Set(configuredModeIds);
@@ -89,10 +94,11 @@
  const selectedCanTransit = $derived(selectedMode?.configured === true);
  const isCurrentSelected = $derived(selectedMode?.id === currentModeId);
  const transitDisabled = $derived(
-  loading || mutating || loadError !== null || !selectedMode || !selectedCanTransit || isCurrentSelected,
+  loading || mutating || planLoading || loadError !== null || !selectedMode || !selectedCanTransit || isCurrentSelected,
  );
  const transitLabel = $derived.by(() => {
   if (mutating) return 'Transiting...';
+  if (planLoading) return 'Planning...';
   if (loadError) return 'Transit unavailable';
   if (!selectedMode?.configured) return 'Configure mode first';
   if (isCurrentSelected) return 'Current mode';
@@ -101,6 +107,20 @@
 
  onMount(() => {
   void refreshModes();
+ });
+
+ $effect(() => {
+  const target = selectedMode?.configured ? selectedMode.id : null;
+  const current = currentModeId;
+  if (!target || loadError) {
+   planRequestSeq += 1;
+   planLoading = false;
+   transitionPlan = null;
+   planError = null;
+   return;
+  }
+  void current;
+  void refreshTransitionPlan(target);
  });
 
  function modeCardClass(selected: boolean): string {
@@ -133,12 +153,35 @@
   mutating = true;
   mutationError = null;
   try {
-   const next = await api.putCurrentMode({ mode: selectedMode.id });
+   const next = await api.modeTransit({
+    mode: selectedMode.id,
+    dry_run: false,
+    reason: 'gui',
+   });
    currentModeId = next.mode;
+   transitionPlan = next.plan;
+   managedAppOps = next.managed_apps ?? [];
   } catch (e) {
    mutationError = formatError(e);
   } finally {
    mutating = false;
+  }
+ }
+
+ async function refreshTransitionPlan(target: string): Promise<void> {
+  const seq = ++planRequestSeq;
+  planLoading = true;
+  planError = null;
+  try {
+   const plan = await api.modePlan({ target });
+   if (seq !== planRequestSeq) return;
+   transitionPlan = plan;
+  } catch (e) {
+   if (seq !== planRequestSeq) return;
+   transitionPlan = null;
+   planError = formatError(e);
+  } finally {
+   if (seq === planRequestSeq) planLoading = false;
   }
  }
 
@@ -232,6 +275,39 @@
      </div>
     </div>
 
+    {#if selectedMode.configured}
+     <div class="rounded border border-surface-200-800 bg-surface-100-900 p-3">
+      <div class="mb-2 flex items-center justify-between gap-2">
+       <div class="text-xs font-semibold opacity-70">Dry-run plan</div>
+       <div class="text-[10px] uppercase opacity-55">{planLoading ? 'loading' : transitionPlan?.noop ? 'noop' : 'change'}</div>
+      </div>
+      {#if planError}
+       <div class="text-xs text-error-500">{planError}</div>
+      {:else if transitionPlan}
+       <dl class="grid grid-cols-[76px_minmax(0,1fr)] gap-x-2 gap-y-1 text-xs">
+        <dt class="opacity-60">From</dt>
+        <dd class="truncate font-mono">{transitionPlan.from_effective_id || '(none)'}</dd>
+        <dt class="opacity-60">To</dt>
+        <dd class="truncate font-mono">{transitionPlan.to_effective_id || '(none)'}</dd>
+        <dt class="opacity-60">Enable +</dt>
+        <dd class="truncate font-mono">
+         {transitionPlan.flowgraph_enable_added_vs_from.length > 0
+          ? transitionPlan.flowgraph_enable_added_vs_from.join(', ')
+          : '-'}
+        </dd>
+        <dt class="opacity-60">Disable +</dt>
+        <dd class="truncate font-mono">
+         {transitionPlan.flowgraph_disable_added_vs_from.length > 0
+          ? transitionPlan.flowgraph_disable_added_vs_from.join(', ')
+          : '-'}
+        </dd>
+       </dl>
+      {:else}
+       <div class="text-xs opacity-60">No dry-run plan.</div>
+      {/if}
+     </div>
+    {/if}
+
     <div>
      <div class="mb-1 text-xs font-semibold opacity-70">Managed Apps</div>
      <ul class="grid gap-1">
@@ -257,6 +333,20 @@
     >
      {transitLabel}
     </button>
+    {#if managedAppOps.length > 0}
+     <div>
+      <div class="mb-1 text-xs font-semibold opacity-70">Last Managed App ops</div>
+      <ul class="grid gap-1">
+       {#each managedAppOps as op}
+        <li class="rounded bg-surface-100-900 px-2 py-1 text-xs">
+         <span class="font-mono">{op.op}</span>
+         <span class="ml-1">{op.id}</span>
+         <span class={op.ok ? 'ml-2 text-success-500' : 'ml-2 text-error-500'}>{op.ok ? 'ok' : 'failed'}</span>
+        </li>
+       {/each}
+      </ul>
+     </div>
+    {/if}
     {:else}
      <div class="px-2 py-6 text-center text-sm opacity-60">No runtime mode candidate.</div>
     {/if}

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -1,17 +1,79 @@
 <script lang="ts">
- const plannedModes = [
-  { id: 'daily', label: 'Daily', state: 'planned' },
-  { id: 'streaming', label: 'Streaming', state: 'planned' },
-  { id: 'work', label: 'Work', state: 'planned' },
-  { id: 'sleep', label: 'Sleep', state: 'planned' },
-  { id: 'rta', label: 'RTA', state: 'planned' },
+ type PlannedMode = {
+  id: string;
+  label: string;
+  description: string;
+  flowgraphGroups: string[];
+  managedApps: string[];
+  notifications: string;
+ };
+
+ const plannedModes: PlannedMode[] = [
+  {
+   id: 'daily',
+   label: 'Daily',
+   description: 'Assistant, alerts, and lightweight personal automations.',
+   flowgraphGroups: ['assistant', 'alerts', 'rss'],
+   managedApps: ['stop obs', 'stop warudo', 'stop tts'],
+   notifications: 'normal',
+  },
+  {
+   id: 'streaming',
+   label: 'Streaming',
+   description: 'Streaming stack, avatar tools, OBS control, and stream-safe alerts.',
+   flowgraphGroups: ['assistant', 'streaming', 'avatar', 'obs'],
+   managedApps: ['start obs', 'start warudo', 'start tts'],
+   notifications: 'stream_safe',
+  },
+  {
+   id: 'work',
+   label: 'Work',
+   description: 'Reduced interruptions while keeping critical alerts and assistant access.',
+   flowgraphGroups: ['assistant', 'alerts'],
+   managedApps: ['stop obs', 'stop warudo', 'stop tts'],
+   notifications: 'important_only',
+  },
+  {
+   id: 'sleep',
+   label: 'Sleep',
+   description: 'Only critical monitoring and emergency notification flows.',
+   flowgraphGroups: ['emergency_alerts'],
+   managedApps: ['stop obs', 'stop warudo', 'stop tts'],
+   notifications: 'critical_only',
+  },
+  {
+   id: 'rta',
+   label: 'RTA',
+   description: 'Game/run-specific timers, splits, alerts, and reduced background noise.',
+   flowgraphGroups: ['game', 'timer', 'alerts'],
+   managedApps: ['leave game tools', 'stop streaming extras'],
+   notifications: 'run_safe',
+  },
  ] as const;
+
+ let selectedModeId = $state('streaming');
+ const selectedMode = $derived(plannedModes.find((m) => m.id === selectedModeId) ?? plannedModes[0]);
+
+ function modeCardClass(selected: boolean): string {
+  return [
+   'rounded border p-4 text-left transition-colors',
+   selected
+    ? 'border-primary-500 bg-primary-500/10'
+    : 'border-surface-200-800 bg-surface-50-950 hover:bg-surface-100-900',
+  ].join(' ');
+ }
 </script>
 
 <section class="grid gap-4">
- <div>
-  <h2 class="text-xl font-semibold">Modes</h2>
-  <p class="text-sm opacity-65">Runtime mode control</p>
+ <div class="flex flex-wrap items-start justify-between gap-3">
+  <div>
+   <h2 class="text-xl font-semibold">Modes</h2>
+   <p class="text-sm opacity-65">Runtime mode control</p>
+  </div>
+  <div class="rounded border border-surface-200-800 bg-surface-50-950 px-3 py-2 text-xs">
+   <span class="opacity-60">Current backend:</span>
+   <span class="ml-1 font-semibold text-warning-500">not available</span>
+  </div>
  </div>
 
  <div class="rounded border border-warning-500/45 bg-warning-500/10 px-4 py-3 text-sm">
@@ -19,13 +81,75 @@
   transition preview, mode switching, and Flowgraph / Managed App desired-state changes.
  </div>
 
- <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-  {#each plannedModes as mode}
-   <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
-    <div class="text-sm font-semibold">{mode.label}</div>
-    <div class="mt-2 text-xs uppercase tracking-wide opacity-55">{mode.state}</div>
-   </article>
-  {/each}
+ <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+  <div class="grid gap-3 md:grid-cols-2">
+   {#each plannedModes as mode}
+    {@const selected = selectedMode.id === mode.id}
+    <button
+     type="button"
+     class={modeCardClass(selected)}
+     aria-pressed={selected}
+     onclick={() => (selectedModeId = mode.id)}
+    >
+     <div class="flex items-center justify-between gap-3">
+      <div class="text-sm font-semibold">{mode.label}</div>
+      <div class="rounded bg-surface-200-800 px-1.5 py-0.5 text-[10px] uppercase opacity-70">
+       planned
+      </div>
+     </div>
+     <p class="mt-2 text-xs leading-relaxed opacity-70">{mode.description}</p>
+     <div class="mt-3 flex flex-wrap gap-1">
+      {#each mode.flowgraphGroups.slice(0, 3) as group}
+       <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-[10px]">{group}</code>
+      {/each}
+     </div>
+    </button>
+   {/each}
+  </div>
+
+  <aside class="rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="border-b border-surface-200-800 px-4 py-2 text-sm font-semibold">
+    Transition Preview
+   </div>
+   <div class="grid gap-4 p-4 text-sm">
+    <div>
+     <div class="text-xs uppercase tracking-wide opacity-60">Target</div>
+     <div class="mt-1 text-lg font-semibold">{selectedMode.label}</div>
+     <p class="mt-1 text-xs opacity-70">{selectedMode.description}</p>
+    </div>
+
+    <div>
+     <div class="mb-1 text-xs font-semibold opacity-70">Flowgraph groups</div>
+     <div class="flex flex-wrap gap-1">
+      {#each selectedMode.flowgraphGroups as group}
+       <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-xs">{group}</code>
+      {/each}
+     </div>
+    </div>
+
+    <div>
+     <div class="mb-1 text-xs font-semibold opacity-70">Managed Apps</div>
+     <ul class="grid gap-1">
+      {#each selectedMode.managedApps as action}
+       <li class="rounded bg-surface-100-900 px-2 py-1 text-xs">{action}</li>
+      {/each}
+     </ul>
+    </div>
+
+    <div>
+     <div class="mb-1 text-xs font-semibold opacity-70">Notifications</div>
+     <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-xs">{selectedMode.notifications}</code>
+    </div>
+
+    <button
+     type="button"
+     class="rounded border border-surface-300-700 px-3 py-1.5 text-xs opacity-55"
+     disabled
+     title="Runtime Mode backend is not implemented yet"
+    >
+     Transit unavailable
+    </button>
+   </div>
+  </aside>
  </div>
 </section>
-

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+ import { onMount } from 'svelte';
+ import { api } from '../api';
+ import { ControlApiError } from '../types';
+
  type PlannedMode = {
   id: string;
   label: string;
@@ -6,6 +10,10 @@
   flowgraphGroups: string[];
   managedApps: string[];
   notifications: string;
+ };
+
+ type DisplayMode = PlannedMode & {
+  configured: boolean;
  };
 
  const plannedModes: PlannedMode[] = [
@@ -51,16 +59,93 @@
   },
  ] as const;
 
+ let configuredModeIds = $state<string[]>([]);
+ let currentModeId = $state<string | null>(null);
  let selectedModeId = $state('streaming');
- const selectedMode = $derived(plannedModes.find((m) => m.id === selectedModeId) ?? plannedModes[0]);
+ let loading = $state(true);
+ let loadError = $state<string | null>(null);
+ let mutating = $state(false);
+ let mutationError = $state<string | null>(null);
+
+ const displayModes = $derived.by<DisplayMode[]>(() => {
+  const configured = new Set(configuredModeIds);
+  const known = new Set(plannedModes.map((m) => m.id));
+  const plannedRows = plannedModes.map((m) => ({ ...m, configured: configured.has(m.id) }));
+  const customRows = configuredModeIds
+   .filter((id) => !known.has(id))
+   .map((id) => ({
+    id,
+    label: id,
+    description: 'Configured runtime mode from conf.',
+    flowgraphGroups: ['configured'],
+    managedApps: ['use configured desired state'],
+    notifications: 'configured',
+    configured: true,
+   }));
+  return [...customRows, ...plannedRows];
+ });
+
+ const selectedMode = $derived(displayModes.find((m) => m.id === selectedModeId) ?? displayModes[0]);
+ const selectedCanTransit = $derived(selectedMode?.configured === true);
+ const isCurrentSelected = $derived(selectedMode?.id === currentModeId);
+ const transitDisabled = $derived(
+  loading || mutating || loadError !== null || !selectedMode || !selectedCanTransit || isCurrentSelected,
+ );
+ const transitLabel = $derived.by(() => {
+  if (mutating) return 'Transiting...';
+  if (loadError) return 'Transit unavailable';
+  if (!selectedMode?.configured) return 'Configure mode first';
+  if (isCurrentSelected) return 'Current mode';
+  return 'Transit';
+ });
+
+ onMount(() => {
+  void refreshModes();
+ });
 
  function modeCardClass(selected: boolean): string {
   return [
    'rounded border p-4 text-left transition-colors',
    selected
     ? 'border-primary-500 bg-primary-500/10'
-    : 'border-surface-200-800 bg-surface-50-950 hover:bg-surface-100-900',
+   : 'border-surface-200-800 bg-surface-50-950 hover:bg-surface-100-900',
   ].join(' ');
+ }
+
+ async function refreshModes(): Promise<void> {
+  loading = true;
+  loadError = null;
+  try {
+   const [list, current] = await Promise.all([api.modesList(), api.currentMode()]);
+   configuredModeIds = list.mode_ids;
+   currentModeId = current.mode;
+   if (current.mode) selectedModeId = current.mode;
+   else if (list.mode_ids.length > 0) selectedModeId = list.mode_ids[0];
+  } catch (e) {
+   loadError = formatError(e);
+  } finally {
+   loading = false;
+  }
+ }
+
+ async function transitSelectedMode(): Promise<void> {
+  if (transitDisabled || !selectedMode) return;
+  mutating = true;
+  mutationError = null;
+  try {
+   const next = await api.putCurrentMode({ mode: selectedMode.id });
+   currentModeId = next.mode;
+  } catch (e) {
+   mutationError = formatError(e);
+  } finally {
+   mutating = false;
+  }
+ }
+
+ function formatError(e: unknown): string {
+  if (e instanceof ControlApiError) return `${e.status} ${e.statusText}`;
+  if (e instanceof Error) return e.message;
+  return String(e);
  }
 </script>
 
@@ -72,19 +157,38 @@
   </div>
   <div class="rounded border border-surface-200-800 bg-surface-50-950 px-3 py-2 text-xs">
    <span class="opacity-60">Current backend:</span>
-   <span class="ml-1 font-semibold text-warning-500">not available</span>
+   <span
+    class="ml-1 font-semibold"
+    class:text-warning-500={loading}
+    class:text-error-500={loadError !== null}
+    class:text-success-500={!loading && loadError === null}
+   >
+    {loading ? 'loading' : loadError ? 'error' : 'available'}
+   </span>
   </div>
  </div>
 
- <div class="rounded border border-warning-500/45 bg-warning-500/10 px-4 py-3 text-sm">
-  Runtime Mode backend is not available in this branch. This surface is reserved for
-  transition preview, mode switching, and Flowgraph / Managed App desired-state changes.
+ <div class="rounded border border-surface-200-800 bg-surface-50-950 px-4 py-3 text-sm">
+  <span class="font-semibold">Current mode:</span>
+  <code class="ml-2 rounded bg-surface-100-900 px-1.5 py-0.5">{currentModeId ?? '(default)'}</code>
+  <span class="ml-3 opacity-65">Configured modes: {configuredModeIds.length}</span>
  </div>
+
+ {#if loadError}
+  <div class="rounded border border-error-500 bg-error-100-900 px-4 py-3 text-sm text-error-900-100">
+   Runtime Mode API failed: {loadError}
+  </div>
+ {/if}
+ {#if mutationError}
+  <div class="rounded border border-error-500 bg-error-100-900 px-4 py-3 text-sm text-error-900-100">
+   Runtime Mode transition failed: {mutationError}
+  </div>
+ {/if}
 
  <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
   <div class="grid gap-3 md:grid-cols-2">
-   {#each plannedModes as mode}
-    {@const selected = selectedMode.id === mode.id}
+   {#each displayModes as mode}
+    {@const selected = selectedMode?.id === mode.id}
     <button
      type="button"
      class={modeCardClass(selected)}
@@ -94,7 +198,7 @@
      <div class="flex items-center justify-between gap-3">
       <div class="text-sm font-semibold">{mode.label}</div>
       <div class="rounded bg-surface-200-800 px-1.5 py-0.5 text-[10px] uppercase opacity-70">
-       planned
+       {mode.configured ? 'configured' : 'planned'}
       </div>
      </div>
      <p class="mt-2 text-xs leading-relaxed opacity-70">{mode.description}</p>
@@ -112,6 +216,7 @@
     Transition Preview
    </div>
    <div class="grid gap-4 p-4 text-sm">
+    {#if selectedMode}
     <div>
      <div class="text-xs uppercase tracking-wide opacity-60">Target</div>
      <div class="mt-1 text-lg font-semibold">{selectedMode.label}</div>
@@ -143,12 +248,18 @@
 
     <button
      type="button"
-     class="rounded border border-surface-300-700 px-3 py-1.5 text-xs opacity-55"
-     disabled
-     title="Runtime Mode backend is not implemented yet"
+     class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900 disabled:opacity-55 disabled:hover:bg-transparent"
+     disabled={transitDisabled}
+     title={selectedMode.configured
+      ? 'Request Runtime Mode transition'
+      : 'This planned mode is not present in conf [modes] yet'}
+     onclick={() => void transitSelectedMode()}
     >
-     Transit unavailable
+     {transitLabel}
     </button>
+    {:else}
+     <div class="px-2 py-6 text-center text-sm opacity-60">No runtime mode candidate.</div>
+    {/if}
    </div>
   </aside>
  </div>

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -91,6 +91,7 @@
  });
 
  const selectedMode = $derived(displayModes.find((m) => m.id === selectedModeId) ?? displayModes[0]);
+ const managedDesiredRows = $derived(managedDirectiveRows(transitionPlan));
  const selectedCanTransit = $derived(selectedMode?.configured === true);
  const isCurrentSelected = $derived(selectedMode?.id === currentModeId);
  const transitDisabled = $derived(
@@ -190,6 +191,20 @@
   if (e instanceof Error) return e.message;
   return String(e);
  }
+
+ function joinList(values: string[]): string {
+  return values.length > 0 ? values.join(', ') : '-';
+ }
+
+ function managedDirectiveRows(plan: ModeTransitionPlan | null): Array<{ label: string; values: string[] }> {
+  if (!plan) return [];
+  return [
+   { label: 'Start', values: plan.target_managed_apps.start },
+   { label: 'Stop', values: plan.target_managed_apps.stop },
+   { label: 'Minimize', values: plan.target_managed_apps.minimize },
+   { label: 'Leave', values: plan.target_managed_apps.leave },
+  ].filter((row) => row.values.length > 0);
+ }
 </script>
 
 <section class="grid gap-4">
@@ -267,12 +282,21 @@
     </div>
 
     <div>
-     <div class="mb-1 text-xs font-semibold opacity-70">Flowgraph groups</div>
-     <div class="flex flex-wrap gap-1">
-      {#each selectedMode.flowgraphGroups as group}
-       <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-xs">{group}</code>
-      {/each}
-     </div>
+     <div class="mb-1 text-xs font-semibold opacity-70">Flowgraph desired state</div>
+     {#if transitionPlan}
+      <dl class="grid grid-cols-[64px_minmax(0,1fr)] gap-x-2 gap-y-1 text-xs">
+       <dt class="opacity-60">Enable</dt>
+       <dd class="truncate font-mono">{joinList(transitionPlan.target_flowgraph_groups.enable)}</dd>
+       <dt class="opacity-60">Disable</dt>
+       <dd class="truncate font-mono">{joinList(transitionPlan.target_flowgraph_groups.disable)}</dd>
+      </dl>
+     {:else}
+      <div class="flex flex-wrap gap-1">
+       {#each selectedMode.flowgraphGroups as group}
+        <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-xs">{group}</code>
+       {/each}
+      </div>
+     {/if}
     </div>
 
     {#if selectedMode.configured}
@@ -309,12 +333,23 @@
     {/if}
 
     <div>
-     <div class="mb-1 text-xs font-semibold opacity-70">Managed Apps</div>
-     <ul class="grid gap-1">
-      {#each selectedMode.managedApps as action}
-       <li class="rounded bg-surface-100-900 px-2 py-1 text-xs">{action}</li>
-      {/each}
-     </ul>
+     <div class="mb-1 text-xs font-semibold opacity-70">Managed App desired state</div>
+     {#if managedDesiredRows.length > 0}
+      <dl class="grid grid-cols-[64px_minmax(0,1fr)] gap-x-2 gap-y-1 text-xs">
+       {#each managedDesiredRows as row}
+        <dt class="opacity-60">{row.label}</dt>
+        <dd class="truncate font-mono">{joinList(row.values)}</dd>
+       {/each}
+      </dl>
+     {:else if transitionPlan}
+      <div class="rounded bg-surface-100-900 px-2 py-1 text-xs opacity-60">No managed app changes.</div>
+     {:else}
+      <ul class="grid gap-1">
+       {#each selectedMode.managedApps as action}
+        <li class="rounded bg-surface-100-900 px-2 py-1 text-xs">{action}</li>
+       {/each}
+      </ul>
+     {/if}
     </div>
 
     <div>

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+ const plannedModes = [
+  { id: 'daily', label: 'Daily', state: 'planned' },
+  { id: 'streaming', label: 'Streaming', state: 'planned' },
+  { id: 'work', label: 'Work', state: 'planned' },
+  { id: 'sleep', label: 'Sleep', state: 'planned' },
+  { id: 'rta', label: 'RTA', state: 'planned' },
+ ] as const;
+</script>
+
+<section class="grid gap-4">
+ <div>
+  <h2 class="text-xl font-semibold">Modes</h2>
+  <p class="text-sm opacity-65">Runtime mode control</p>
+ </div>
+
+ <div class="rounded border border-warning-500/45 bg-warning-500/10 px-4 py-3 text-sm">
+  Runtime Mode backend is not available in this branch. This surface is reserved for
+  transition preview, mode switching, and Flowgraph / Managed App desired-state changes.
+ </div>
+
+ <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+  {#each plannedModes as mode}
+   <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
+    <div class="text-sm font-semibold">{mode.label}</div>
+    <div class="mt-2 text-xs uppercase tracking-wide opacity-55">{mode.state}</div>
+   </article>
+  {/each}
+ </div>
+</section>
+

--- a/gui/src/lib/tabs/NowTab.svelte
+++ b/gui/src/lib/tabs/NowTab.svelte
@@ -2,7 +2,9 @@
  import { onMount } from 'svelte';
  import { api } from '../api';
  import { eventsStore } from '../events.svelte';
+ import { tabNavStore, type TabId } from '../tabs.svelte';
  import type {
+  ControlEvent,
   FlowgraphDiagnosticsResponse,
   FlowgraphTreeResponse,
   ManagedAppsResponse,
@@ -71,22 +73,86 @@
     ? 'text-warning-500'
     : 'text-error-500',
  );
+ const healthTone = $derived.by(() => {
+  if (error || eventsStore.connection === 'error' || eventsStore.connection === 'closed') {
+   return { label: 'Needs attention', className: 'text-error-500' };
+  }
+  if (diagnosticErrors > 0) return { label: 'Flowgraph errors', className: 'text-error-500' };
+  if (diagnosticWarnings > 0) return { label: 'Warnings', className: 'text-warning-500' };
+  return { label: 'Operational', className: 'text-success-500' };
+ });
+ const topDiagnostics = $derived(diagnostics?.diagnostics.slice(0, 5) ?? []);
+ const topManagedApps = $derived(managedApps?.entries.slice(0, 6) ?? []);
+
+ function go(tab: TabId) {
+  tabNavStore.setActive(tab);
+ }
+
+ function summarizeEvent(ev: ControlEvent): string {
+  switch (ev.kind) {
+   case 'channel_datum':
+    return `${ev.channel}: ${ev.content}`;
+   case 'lagged':
+    return `${ev.dropped} dropped`;
+   case 'heartbeat':
+    return ev.now;
+   case 'pause_state':
+    return ev.paused ? `${ev.target} paused` : `${ev.target} resumed`;
+   case 'reloaded':
+    return `${ev.target}${ev.id ? `:${ev.id}` : ''}`;
+   case 'oauth_status':
+    return `${ev.account} ${ev.status}`;
+   case 'processor_invoked':
+    return `${ev.feature} ${ev.outcome} (${ev.elapsed_ms}ms)`;
+   case 'restarting':
+    return `pid ${ev.current_pid} -> ${ev.new_pid}`;
+   case 'managed_app_state':
+    return `${ev.id} ${ev.running ? 'running' : 'stopped'}`;
+   case 'flowgraph_reloaded':
+    return `${ev.node_count} nodes, ${ev.error_count} errors`;
+  }
+ }
 </script>
 
 <section class="grid gap-4">
  <div class="flex flex-wrap items-start justify-between gap-3">
   <div>
    <h2 class="text-xl font-semibold">Now</h2>
-   <p class="text-sm opacity-65">Runtime cockpit</p>
+   <p class="text-sm opacity-65">
+    Runtime cockpit · <span class={healthTone.className}>{healthTone.label}</span>
+   </p>
   </div>
-  <button
-   type="button"
-   class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900 disabled:opacity-50"
-   disabled={loading}
-   onclick={refreshNow}
-  >
-   {loading ? 'Refreshing...' : 'Refresh'}
-  </button>
+  <div class="flex flex-wrap items-center gap-2">
+   <button
+    type="button"
+    class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900"
+    onclick={() => go('modes')}
+   >
+    Modes
+   </button>
+   <button
+    type="button"
+    class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900"
+    onclick={() => go('flowgraph')}
+   >
+    Flowgraph Studio
+   </button>
+   <button
+    type="button"
+    class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900"
+    onclick={() => go('resources')}
+   >
+    Resources
+   </button>
+   <button
+    type="button"
+    class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900 disabled:opacity-50"
+    disabled={loading}
+    onclick={refreshNow}
+   >
+    {loading ? 'Refreshing...' : 'Refresh'}
+   </button>
+  </div>
  </div>
 
  {#if error}
@@ -147,6 +213,68 @@
   </section>
 
   <section class="rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="border-b border-surface-200-800 px-4 py-2 text-sm font-semibold">Managed Apps</div>
+   <div class="max-h-72 overflow-y-auto p-2">
+    {#if topManagedApps.length === 0}
+     <div class="px-2 py-4 text-sm opacity-60">No managed apps registered.</div>
+    {:else}
+     <ul class="grid gap-1">
+      {#each topManagedApps as app (app.id)}
+       <li class="rounded bg-surface-100-900 px-2 py-1.5 text-xs">
+        <div class="flex items-center justify-between gap-2">
+         <span class="truncate font-medium">{app.label}</span>
+         <span class={app.status.running ? 'text-success-500' : 'opacity-55'}>
+          {app.status.running ? 'running' : 'stopped'}
+         </span>
+        </div>
+       </li>
+      {/each}
+     </ul>
+    {/if}
+   </div>
+  </section>
+ </div>
+
+ <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+  <section class="rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="flex items-center justify-between border-b border-surface-200-800 px-4 py-2">
+    <span class="text-sm font-semibold">Flowgraph Problems</span>
+    <button
+     type="button"
+     class="rounded border border-surface-300-700 px-2 py-0.5 text-xs hover:bg-surface-100-900"
+     onclick={() => go('flowgraph')}
+    >
+     Open
+    </button>
+   </div>
+   <div class="max-h-72 overflow-y-auto p-2">
+    {#if topDiagnostics.length === 0}
+     <div class="px-2 py-4 text-sm opacity-60">No Flowgraph diagnostics.</div>
+    {:else}
+     <ul class="grid gap-1">
+      {#each topDiagnostics as d, i (`${d.file ?? ''}:${d.node ?? ''}:${d.code}:${i}`)}
+       <li class="rounded bg-surface-100-900 px-2 py-1.5 text-xs">
+        <div class="flex items-center gap-2">
+         <span
+          class="rounded px-1.5 py-0.5 text-[10px] uppercase"
+          class:bg-error-500={d.severity === 'error'}
+          class:text-white={d.severity === 'error'}
+          class:bg-warning-500={d.severity === 'warning'}
+          class:bg-surface-300-700={d.severity === 'info'}
+         >
+          {d.severity}
+         </span>
+         <span class="font-mono opacity-70">{d.code}</span>
+        </div>
+        <div class="mt-1">{d.message}</div>
+       </li>
+      {/each}
+     </ul>
+    {/if}
+   </div>
+  </section>
+
+  <section class="rounded border border-surface-200-800 bg-surface-50-950">
    <div class="border-b border-surface-200-800 px-4 py-2 text-sm font-semibold">Recent Events</div>
    <div class="max-h-72 overflow-y-auto p-2">
     {#if recentEvents.length === 0}
@@ -159,6 +287,9 @@
          <span class="font-mono">{item.event.kind}</span>
          <span class="opacity-55">{new Date(item.received_at).toLocaleTimeString()}</span>
         </div>
+        <div class="mt-1 truncate opacity-70" title={summarizeEvent(item.event)}>
+         {summarizeEvent(item.event)}
+        </div>
        </li>
       {/each}
      </ul>
@@ -167,4 +298,3 @@
   </section>
  </div>
 </section>
-

--- a/gui/src/lib/tabs/NowTab.svelte
+++ b/gui/src/lib/tabs/NowTab.svelte
@@ -7,11 +7,12 @@
   ControlEvent,
   FlowgraphDiagnosticsResponse,
   FlowgraphTreeResponse,
-  ManagedAppsResponse,
-  StateSnapshot,
+ ManagedAppsResponse,
+ StateSnapshot,
  } from '../types';
 
  let snapshot = $state<StateSnapshot | null>(null);
+ let currentMode = $state<string | null>(null);
  let managedApps = $state<ManagedAppsResponse | null>(null);
  let flowgraphTree = $state<FlowgraphTreeResponse | null>(null);
  let diagnostics = $state<FlowgraphDiagnosticsResponse | null>(null);
@@ -22,13 +23,15 @@
   loading = true;
   error = null;
   try {
-   const [nextSnapshot, nextManagedApps, nextTree, nextDiagnostics] = await Promise.all([
+   const [nextSnapshot, nextMode, nextManagedApps, nextTree, nextDiagnostics] = await Promise.all([
     api.snapshot(),
+    api.currentMode(),
     api.managedApps(),
     api.flowgraphTree(),
     api.flowgraphDiagnostics(),
    ]);
    snapshot = nextSnapshot;
+   currentMode = nextMode.mode;
    managedApps = nextManagedApps;
    flowgraphTree = nextTree;
    diagnostics = nextDiagnostics;
@@ -161,13 +164,27 @@
   </div>
  {/if}
 
- <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+ <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
   <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
    <div class="text-xs uppercase tracking-wide opacity-60">Connection</div>
    <div class="mt-2 text-2xl font-semibold {wsTone}">{eventsStore.connection}</div>
    <div class="mt-1 text-xs opacity-60">
     {eventsStore.received_count} events / {eventsStore.dropped_count} dropped
    </div>
+  </article>
+
+  <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
+   <div class="text-xs uppercase tracking-wide opacity-60">Mode</div>
+   <div class="mt-2 truncate text-2xl font-semibold" title={currentMode ?? '(default)'}>
+    {currentMode ?? 'default'}
+   </div>
+   <button
+    type="button"
+    class="mt-1 text-xs text-primary-600-400 hover:underline"
+    onclick={() => go('modes')}
+   >
+    manage
+   </button>
   </article>
 
   <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
@@ -199,6 +216,8 @@
     <dd class="font-mono">{snapshot?.app_version ?? '-'}</dd>
     <dt class="opacity-60">Session</dt>
     <dd class="truncate font-mono">{snapshot?.runtime.session_id ?? '-'}</dd>
+    <dt class="opacity-60">Mode</dt>
+    <dd class="font-mono">{currentMode ?? '(default)'}</dd>
     <dt class="opacity-60">Root</dt>
     <dd class="truncate font-mono">{snapshot?.runtime.root ?? '-'}</dd>
     <dt class="opacity-60">Twitch</dt>

--- a/gui/src/lib/tabs/NowTab.svelte
+++ b/gui/src/lib/tabs/NowTab.svelte
@@ -113,6 +113,12 @@
     return `${ev.id} ${ev.running ? 'running' : 'stopped'}`;
    case 'flowgraph_reloaded':
     return `${ev.node_count} nodes, ${ev.error_count} errors`;
+   case 'restart_recommended':
+    return ev.reason;
+   case 'runtime_mode_changed':
+    return `${ev.previous_effective_id || '(none)'} -> ${ev.current_effective_id || '(none)'}`;
+   case 'runtime_mode_managed_apps':
+    return `${ev.ops.length} managed app ops`;
   }
  }
 </script>

--- a/gui/src/lib/tabs/NowTab.svelte
+++ b/gui/src/lib/tabs/NowTab.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+ import { onMount } from 'svelte';
+ import { api } from '../api';
+ import { eventsStore } from '../events.svelte';
+ import type {
+  FlowgraphDiagnosticsResponse,
+  FlowgraphTreeResponse,
+  ManagedAppsResponse,
+  StateSnapshot,
+ } from '../types';
+
+ let snapshot = $state<StateSnapshot | null>(null);
+ let managedApps = $state<ManagedAppsResponse | null>(null);
+ let flowgraphTree = $state<FlowgraphTreeResponse | null>(null);
+ let diagnostics = $state<FlowgraphDiagnosticsResponse | null>(null);
+ let loading = $state(true);
+ let error = $state<string | null>(null);
+
+ async function refreshNow() {
+  loading = true;
+  error = null;
+  try {
+   const [nextSnapshot, nextManagedApps, nextTree, nextDiagnostics] = await Promise.all([
+    api.snapshot(),
+    api.managedApps(),
+    api.flowgraphTree(),
+    api.flowgraphDiagnostics(),
+   ]);
+   snapshot = nextSnapshot;
+   managedApps = nextManagedApps;
+   flowgraphTree = nextTree;
+   diagnostics = nextDiagnostics;
+  } catch (e) {
+   error = e instanceof Error ? e.message : String(e);
+  } finally {
+   loading = false;
+  }
+ }
+
+ onMount(() => {
+  void refreshNow();
+  const off = eventsStore.subscribe((ts) => {
+   if (
+    ts.event.kind === 'heartbeat' ||
+    ts.event.kind === 'pause_state' ||
+    ts.event.kind === 'managed_app_state' ||
+    ts.event.kind === 'flowgraph_reloaded'
+   ) {
+    void refreshNow();
+   }
+  });
+  return off;
+ });
+
+ const aiTotal = $derived(snapshot?.ai_personas.length ?? 0);
+ const aiPaused = $derived(snapshot?.ai_personas.filter((a) => a.paused).length ?? 0);
+ const managedTotal = $derived(managedApps?.entries.length ?? 0);
+ const managedRunning = $derived(managedApps?.entries.filter((a) => a.status.running).length ?? 0);
+ const flowgraphFiles = $derived(flowgraphTree?.files.length ?? 0);
+ const diagnosticErrors = $derived(
+  diagnostics?.diagnostics.filter((d) => d.severity === 'error').length ?? 0,
+ );
+ const diagnosticWarnings = $derived(
+  diagnostics?.diagnostics.filter((d) => d.severity === 'warning').length ?? 0,
+ );
+ const recentEvents = $derived(eventsStore.recent.slice(-8).toReversed());
+ const wsTone = $derived(
+  eventsStore.connection === 'open'
+   ? 'text-success-500'
+   : eventsStore.connection === 'connecting'
+    ? 'text-warning-500'
+    : 'text-error-500',
+ );
+</script>
+
+<section class="grid gap-4">
+ <div class="flex flex-wrap items-start justify-between gap-3">
+  <div>
+   <h2 class="text-xl font-semibold">Now</h2>
+   <p class="text-sm opacity-65">Runtime cockpit</p>
+  </div>
+  <button
+   type="button"
+   class="rounded border border-surface-300-700 px-3 py-1.5 text-xs hover:bg-surface-100-900 disabled:opacity-50"
+   disabled={loading}
+   onclick={refreshNow}
+  >
+   {loading ? 'Refreshing...' : 'Refresh'}
+  </button>
+ </div>
+
+ {#if error}
+  <div class="rounded border border-error-500/50 bg-error-500/10 px-3 py-2 text-sm text-error-600-400">
+   {error}
+  </div>
+ {/if}
+
+ <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+  <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
+   <div class="text-xs uppercase tracking-wide opacity-60">Connection</div>
+   <div class="mt-2 text-2xl font-semibold {wsTone}">{eventsStore.connection}</div>
+   <div class="mt-1 text-xs opacity-60">
+    {eventsStore.received_count} events / {eventsStore.dropped_count} dropped
+   </div>
+  </article>
+
+  <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
+   <div class="text-xs uppercase tracking-wide opacity-60">AI</div>
+   <div class="mt-2 text-2xl font-semibold">{aiTotal - aiPaused} / {aiTotal}</div>
+   <div class="mt-1 text-xs opacity-60">{aiPaused} paused</div>
+  </article>
+
+  <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
+   <div class="text-xs uppercase tracking-wide opacity-60">Managed Apps</div>
+   <div class="mt-2 text-2xl font-semibold">{managedRunning} / {managedTotal}</div>
+   <div class="mt-1 text-xs opacity-60">running</div>
+  </article>
+
+  <article class="rounded border border-surface-200-800 bg-surface-50-950 p-4">
+   <div class="text-xs uppercase tracking-wide opacity-60">Flowgraph</div>
+   <div class="mt-2 text-2xl font-semibold">{flowgraphFiles}</div>
+   <div class="mt-1 text-xs opacity-60">
+    {diagnosticErrors} errors / {diagnosticWarnings} warnings
+   </div>
+  </article>
+ </div>
+
+ <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+  <section class="rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="border-b border-surface-200-800 px-4 py-2 text-sm font-semibold">Runtime</div>
+   <dl class="grid gap-x-4 gap-y-2 p-4 text-sm sm:grid-cols-[160px_minmax(0,1fr)]">
+    <dt class="opacity-60">Version</dt>
+    <dd class="font-mono">{snapshot?.app_version ?? '-'}</dd>
+    <dt class="opacity-60">Session</dt>
+    <dd class="truncate font-mono">{snapshot?.runtime.session_id ?? '-'}</dd>
+    <dt class="opacity-60">Root</dt>
+    <dd class="truncate font-mono">{snapshot?.runtime.root ?? '-'}</dd>
+    <dt class="opacity-60">Twitch</dt>
+    <dd>
+     {#if snapshot?.twitch}
+      {snapshot.twitch.username} -> {snapshot.twitch.channel_to}
+     {:else}
+      <span class="opacity-60">not configured</span>
+     {/if}
+    </dd>
+   </dl>
+  </section>
+
+  <section class="rounded border border-surface-200-800 bg-surface-50-950">
+   <div class="border-b border-surface-200-800 px-4 py-2 text-sm font-semibold">Recent Events</div>
+   <div class="max-h-72 overflow-y-auto p-2">
+    {#if recentEvents.length === 0}
+     <div class="px-2 py-4 text-sm opacity-60">No events yet.</div>
+    {:else}
+     <ul class="grid gap-1">
+      {#each recentEvents as item (item.seq)}
+       <li class="rounded bg-surface-100-900 px-2 py-1.5 text-xs">
+        <div class="flex items-center justify-between gap-2">
+         <span class="font-mono">{item.event.kind}</span>
+         <span class="opacity-55">{new Date(item.received_at).toLocaleTimeString()}</span>
+        </div>
+       </li>
+      {/each}
+     </ul>
+    {/if}
+   </div>
+  </section>
+ </div>
+</section>
+

--- a/gui/src/lib/tabs/ResourcesTab.svelte
+++ b/gui/src/lib/tabs/ResourcesTab.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+ /**
+  * Runtime resources.
+  *
+  * External services, credentials, and child processes live here. Profile
+  * management and developer diagnostics belong to Settings.
+  */
+ import OAuthPanel from '../OAuthPanel.svelte';
+ import PausePanel from '../PausePanel.svelte';
+ import WidgetSlot from '../WidgetSlot.svelte';
+ import RunWithEditorPanel from './RunWithEditorPanel.svelte';
+</script>
+
+<div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+ <div class="space-y-4">
+  <RunWithEditorPanel />
+  <PausePanel />
+ </div>
+ <div class="space-y-4">
+  <OAuthPanel />
+  <WidgetSlot
+   title="Avatar / OBS / TTS connectors"
+   subtitle="future resources"
+   placeholder="OBS、Warudo、TTS、avatar bridge などは Runtime Mode と連動する外部リソースとしてここに集約します。"
+  />
+ </div>
+</div>
+

--- a/gui/src/lib/tabs/SettingsTab.svelte
+++ b/gui/src/lib/tabs/SettingsTab.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+ /**
+  * Runtime settings and developer utilities.
+  *
+  * Durable profile/conf management, reload, and low-level diagnostics are kept
+  * away from Resources so daily operation is less noisy.
+  */
+ import PingStatus from '../PingStatus.svelte';
+ import ReloadPanel from '../ReloadPanel.svelte';
+ import WidgetSlot from '../WidgetSlot.svelte';
+ import ProfileManagerPanel from './ProfileManagerPanel.svelte';
+</script>
+
+<div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+ <div class="space-y-4">
+  <ProfileManagerPanel />
+  <ReloadPanel />
+ </div>
+ <div class="space-y-4">
+  <section class="rounded-lg border border-surface-200-800 bg-surface-100-900 p-4">
+   <h2 class="mb-2 text-sm font-semibold opacity-80">接続情報</h2>
+   <PingStatus />
+  </section>
+  <WidgetSlot
+   title="開発者向けユーティリティ"
+   subtitle="γ-6 予定"
+   placeholder="ログダウンロード、ランタイム診断、ニッチな操作（broadcasters の force_remove 等）を整理します。"
+  />
+ </div>
+</div>
+

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -161,10 +161,59 @@ export type ModesListResponse = {
 
 export type CurrentModeResponse = {
  mode: string | null;
+ managed_apps?: RuntimeModeManagedAppOp[] | null;
 };
 
 export type PutCurrentModeBody = {
  mode: string | null;
+};
+
+export type RuntimeModeManagedAppOp = {
+ id: string;
+ op: string;
+ ok: boolean;
+ detail?: string | null;
+};
+
+export type FlowgraphGroupsModeSpec = {
+ enable: string[];
+ disable: string[];
+};
+
+export type ManagedAppsModeDirective = {
+ start: string[];
+ stop: string[];
+ minimize: string[];
+ leave: string[];
+};
+
+export type ModeTransitionPlan = {
+ from_slot: string | null;
+ to_slot: string | null;
+ from_effective_id: string;
+ to_effective_id: string;
+ noop: boolean;
+ target_flowgraph_groups: FlowgraphGroupsModeSpec;
+ target_managed_apps: ManagedAppsModeDirective;
+ flowgraph_enable_added_vs_from: string[];
+ flowgraph_disable_added_vs_from: string[];
+};
+
+export type ModePlanRequest = {
+ target?: string | null;
+};
+
+export type ModeTransitRequest = {
+ mode?: string | null;
+ dry_run?: boolean;
+ reason?: string | null;
+};
+
+export type ModeTransitResponse = {
+ dry_run: boolean;
+ mode: string | null;
+ plan: ModeTransitionPlan;
+ managed_apps?: RuntimeModeManagedAppOp[] | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -643,6 +692,25 @@ export type ControlEvent =
     error_count: number;
     warning_count: number;
     node_count: number;
+   }
+ | {
+    kind: 'restart_recommended';
+    reason: string;
+    details: unknown;
+   }
+ | {
+    kind: 'runtime_mode_changed';
+    previous_slot?: string | null;
+    current_slot?: string | null;
+    previous_effective_id: string;
+    current_effective_id: string;
+    reason?: string | null;
+   }
+ | {
+    kind: 'runtime_mode_managed_apps';
+    previous_effective_id: string;
+    current_effective_id: string;
+    ops: RuntimeModeManagedAppOp[];
    };
 
 /** ControlEvent の kind 文字列一覧（`never` チェック用ユーティリティ）。 */

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -216,6 +216,31 @@ export type ModeTransitResponse = {
  managed_apps?: RuntimeModeManagedAppOp[] | null;
 };
 
+export type RuntimeModeTransitionPhase =
+ | 'idle'
+ | 'planning'
+ | 'suppressing_flowgraph'
+ | 'applying_mode'
+ | 'applying_managed_apps'
+ | 'firing_flowgraph_hook'
+ | 'completed'
+ | 'failed';
+
+export type RuntimeModeTransitionStatus = {
+ seq: number;
+ active: boolean;
+ phase: RuntimeModeTransitionPhase;
+ step_index: number;
+ step_count: number;
+ message: string;
+ started_at?: string | null;
+ updated_at: string;
+ finished_at?: string | null;
+ error?: string | null;
+ plan?: ModeTransitionPlan | null;
+ managed_apps: RuntimeModeManagedAppOp[];
+};
+
 // ---------------------------------------------------------------------------
 // /oauth/twitch/*
 // ---------------------------------------------------------------------------

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -152,6 +152,22 @@ export type ReloadResponse = {
 };
 
 // ---------------------------------------------------------------------------
+// /modes
+// ---------------------------------------------------------------------------
+
+export type ModesListResponse = {
+ mode_ids: string[];
+};
+
+export type CurrentModeResponse = {
+ mode: string | null;
+};
+
+export type PutCurrentModeBody = {
+ mode: string | null;
+};
+
+// ---------------------------------------------------------------------------
 // /oauth/twitch/*
 // ---------------------------------------------------------------------------
 

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -716,6 +716,16 @@ export type ControlEvent =
 /** ControlEvent の kind 文字列一覧（`never` チェック用ユーティリティ）。 */
 export type ControlEventKind = ControlEvent['kind'];
 
+export type ControlEventHistoryItem = {
+ at: string;
+ event: ControlEvent;
+};
+
+export type ControlEventHistoryResponse = {
+ events: ControlEventHistoryItem[];
+ limit: number;
+};
+
 /**
  * 使用例:
  * ```ts

--- a/gui/tests/e2e/README.md
+++ b/gui/tests/e2e/README.md
@@ -26,6 +26,7 @@ GUI redesign specs are added incrementally and should stay narrow:
 - `main-navigation.spec.ts`
 - `modes-planning.spec.ts`
 - `flowgraph-studio-layout.spec.ts`
+- `observability-layout.spec.ts`
 
 ## Running locally
 

--- a/gui/tests/e2e/README.md
+++ b/gui/tests/e2e/README.md
@@ -50,6 +50,10 @@ attach it via `?token=...` which the GUI's `auth.ts` persists to
 localStorage. There is intentionally **no .env support**: E2E must be
 reproducible across machines.
 
+The fixture also defines side-effect-free Runtime Modes (`daily`,
+`streaming`) so GUI mode switching can exercise the Control API without
+starting external applications.
+
 ## Selector policy
 
 Prefer `getByRole` / `getByLabel` / `getByText`. Only reach for

--- a/gui/tests/e2e/README.md
+++ b/gui/tests/e2e/README.md
@@ -24,6 +24,7 @@ GUI redesign specs are added incrementally and should stay narrow:
 
 - `now-dashboard.spec.ts`
 - `main-navigation.spec.ts`
+- `modes-planning.spec.ts`
 
 ## Running locally
 

--- a/gui/tests/e2e/README.md
+++ b/gui/tests/e2e/README.md
@@ -25,6 +25,7 @@ GUI redesign specs are added incrementally and should stay narrow:
 - `now-dashboard.spec.ts`
 - `main-navigation.spec.ts`
 - `modes-planning.spec.ts`
+- `flowgraph-studio-layout.spec.ts`
 
 ## Running locally
 

--- a/gui/tests/e2e/README.md
+++ b/gui/tests/e2e/README.md
@@ -20,6 +20,11 @@ gui/tests/e2e/
 - `live-quick-add-learn-undo.spec.ts`
 - `channels-ws-live-update.spec.ts`
 
+GUI redesign specs are added incrementally and should stay narrow:
+
+- `now-dashboard.spec.ts`
+- `main-navigation.spec.ts`
+
 ## Running locally
 
 From the repository root:

--- a/gui/tests/e2e/control-panel-smoke.spec.ts
+++ b/gui/tests/e2e/control-panel-smoke.spec.ts
@@ -24,9 +24,9 @@ test.describe('§3.1 control-panel-smoke', () => {
   // `<nav aria-label="Main tabs">` landmark. Scope the lookup to that
   // landmark (§5.3 selector policy).
   const tabs = page.getByRole('navigation', { name: 'Main tabs' });
-  await expect(
-   tabs.getByRole('button', { name: /live/i }),
-  ).toBeVisible({ timeout: 15_000 });
+  await expect(tabs.getByRole('button', { name: /now/i })).toBeVisible({
+   timeout: 15_000,
+  });
 
   // /ping is the lightest endpoint inside the auth-wrapped scope; 200
   // here means routing + bearer_token both work.

--- a/gui/tests/e2e/flowgraph-studio-layout.spec.ts
+++ b/gui/tests/e2e/flowgraph-studio-layout.spec.ts
@@ -20,4 +20,19 @@ test.describe('GUI redesign: Flowgraph Studio layout', () => {
   await expect(main.getByText('Nodes', { exact: true })).toBeVisible();
   await expect(main.getByText('Edges', { exact: true })).toBeVisible();
  });
+
+ test('Flowgraph Studio opens a command palette for editor operations', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}#flowgraph`);
+
+  const main = page.getByRole('main');
+  await main.getByRole('button', { name: 'Commands' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Command Palette' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Reload from disk/ })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Save current file/ })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Import ZIP/ })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Close' }).click();
+  await expect(dialog).toBeHidden();
+ });
 });

--- a/gui/tests/e2e/flowgraph-studio-layout.spec.ts
+++ b/gui/tests/e2e/flowgraph-studio-layout.spec.ts
@@ -30,8 +30,12 @@ test.describe('GUI redesign: Flowgraph Studio layout', () => {
   const dialog = page.getByRole('dialog', { name: 'Command Palette' });
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole('button', { name: /Reload from disk/ })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Undo/ })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Duplicate selection/ })).toBeVisible();
   await expect(dialog.getByRole('button', { name: /Save current file/ })).toBeVisible();
   await expect(dialog.getByRole('button', { name: /Import ZIP/ })).toBeVisible();
+  await dialog.getByPlaceholder('Search commands or node catalog').fill('literal');
+  await expect(dialog.getByRole('button', { name: /Insert/ }).first()).toBeVisible();
   await dialog.getByRole('button', { name: 'Close' }).click();
   await expect(dialog).toBeHidden();
  });

--- a/gui/tests/e2e/flowgraph-studio-layout.spec.ts
+++ b/gui/tests/e2e/flowgraph-studio-layout.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+import { tokenQuery } from './fixtures';
+
+test.describe('GUI redesign: Flowgraph Studio layout', () => {
+ test('Flowgraph Studio exposes IDE-style workspace regions', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}#flowgraph`);
+
+  await expect(page.getByRole('heading', { name: 'Flowgraph Studio' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  const main = page.getByRole('main');
+  await expect(main.getByText('Author, inspect, and repair runtime dataflow files.')).toBeVisible();
+  await expect(main.getByText('Files', { exact: true }).first()).toBeVisible();
+  await expect(main.getByText('Canvas', { exact: true })).toBeVisible();
+  await expect(main.getByText('Node Palette', { exact: true })).toBeVisible();
+  await expect(main.getByText('Inspector', { exact: true })).toBeVisible();
+  await expect(main.getByText('Problems', { exact: true })).toBeVisible();
+  await expect(main.getByText('Nodes', { exact: true })).toBeVisible();
+  await expect(main.getByText('Edges', { exact: true })).toBeVisible();
+ });
+});

--- a/gui/tests/e2e/main-navigation.spec.ts
+++ b/gui/tests/e2e/main-navigation.spec.ts
@@ -19,9 +19,10 @@ test.describe('GUI redesign: main navigation', () => {
   await expect(page.getByText('root =')).toBeVisible({ timeout: 15_000 });
 
   await tabs.getByRole('button', { name: /resources/i }).click();
-  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: '連携アプリ設定（run_with）' })).toBeVisible({
    timeout: 15_000,
   });
+  await expect(page.getByRole('heading', { name: 'OAuth (Twitch Device Code Flow)' })).toBeVisible();
 
   await tabs.getByRole('button', { name: /observability/i }).click();
   await expect(page.getByRole('heading', { name: 'ライブイベント' })).toBeVisible({
@@ -29,8 +30,10 @@ test.describe('GUI redesign: main navigation', () => {
   });
 
   await tabs.getByRole('button', { name: /settings/i }).click();
-  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
    timeout: 15_000,
+  });
+  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
   });
  });
 
@@ -41,7 +44,7 @@ test.describe('GUI redesign: main navigation', () => {
   });
 
   await page.goto(`/gui/${tokenQuery()}#setup`);
-  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: '連携アプリ設定（run_with）' })).toBeVisible({
    timeout: 15_000,
   });
 
@@ -51,8 +54,10 @@ test.describe('GUI redesign: main navigation', () => {
   });
 
   await page.goto(`/gui/${tokenQuery()}#tools`);
-  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
    timeout: 15_000,
+  });
+  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
   });
  });
 });

--- a/gui/tests/e2e/main-navigation.spec.ts
+++ b/gui/tests/e2e/main-navigation.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+
+import { tokenQuery } from './fixtures';
+
+test.describe('GUI redesign: main navigation', () => {
+ test('new top-level surfaces are reachable from the main navigation', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}`);
+
+  const tabs = page.getByRole('navigation', { name: 'Main tabs' });
+  await expect(tabs.getByRole('button', { name: /now/i })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  await tabs.getByRole('button', { name: /modes/i }).click();
+  await expect(page.getByRole('heading', { name: 'Modes' })).toBeVisible();
+  await expect(page.getByText('Runtime mode control')).toBeVisible();
+
+  await tabs.getByRole('button', { name: /flowgraph studio/i }).click();
+  await expect(page.getByText('root =')).toBeVisible({ timeout: 15_000 });
+
+  await tabs.getByRole('button', { name: /resources/i }).click();
+  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  await tabs.getByRole('button', { name: /observability/i }).click();
+  await expect(page.getByRole('heading', { name: 'ライブイベント' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  await tabs.getByRole('button', { name: /settings/i }).click();
+  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
+   timeout: 15_000,
+  });
+ });
+
+ test('legacy hashes fall back to the new information architecture', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}#live`);
+  await expect(page.getByRole('heading', { name: 'Now' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  await page.goto(`/gui/${tokenQuery()}#setup`);
+  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  await page.goto(`/gui/${tokenQuery()}#logs`);
+  await expect(page.getByRole('heading', { name: 'ライブイベント' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  await page.goto(`/gui/${tokenQuery()}#tools`);
+  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
+   timeout: 15_000,
+  });
+ });
+});

--- a/gui/tests/e2e/modes-planning.spec.ts
+++ b/gui/tests/e2e/modes-planning.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+import { tokenQuery } from './fixtures';
+
+test.describe('GUI redesign: Modes planning surface', () => {
+ test('planned modes show transition preview without enabling fake controls', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}#modes`);
+
+  const main = page.getByRole('main');
+  await expect(page.getByRole('heading', { name: 'Modes' })).toBeVisible({
+   timeout: 15_000,
+  });
+  await expect(main.getByText('Transition Preview', { exact: true })).toBeVisible();
+  await expect(main.getByRole('button', { name: 'Transit unavailable' })).toBeDisabled();
+
+  await main.getByRole('button', { name: /Sleep/ }).click();
+  await expect(main.getByText('critical_only')).toBeVisible();
+  await expect(main.getByText('emergency_alerts').last()).toBeVisible();
+
+  await main.getByRole('button', { name: /Streaming/ }).click();
+  await expect(main.getByText('stream_safe')).toBeVisible();
+  await expect(main.getByText('start obs').last()).toBeVisible();
+ });
+});

--- a/gui/tests/e2e/modes-planning.spec.ts
+++ b/gui/tests/e2e/modes-planning.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { tokenQuery } from './fixtures';
 
 test.describe('GUI redesign: Modes planning surface', () => {
- test('planned modes show transition preview without enabling fake controls', async ({ page }) => {
+ test('planned modes show transition preview and Runtime Mode backend status', async ({ page }) => {
   await page.goto(`/gui/${tokenQuery()}#modes`);
 
   const main = page.getByRole('main');
@@ -11,11 +11,14 @@ test.describe('GUI redesign: Modes planning surface', () => {
    timeout: 15_000,
   });
   await expect(main.getByText('Transition Preview', { exact: true })).toBeVisible();
-  await expect(main.getByRole('button', { name: 'Transit unavailable' })).toBeDisabled();
+  await expect(main.getByText('Current mode:')).toBeVisible();
+  await expect(main.getByText('Configured modes:')).toBeVisible();
+  await expect(main.getByRole('button', { name: 'Configure mode first' })).toBeDisabled();
 
   await main.getByRole('button', { name: /Sleep/ }).click();
   await expect(main.getByText('critical_only')).toBeVisible();
   await expect(main.getByText('emergency_alerts').last()).toBeVisible();
+  await expect(main.getByRole('button', { name: 'Configure mode first' })).toBeDisabled();
 
   await main.getByRole('button', { name: /Streaming/ }).click();
   await expect(main.getByText('stream_safe')).toBeVisible();

--- a/gui/tests/e2e/modes-planning.spec.ts
+++ b/gui/tests/e2e/modes-planning.spec.ts
@@ -13,7 +13,7 @@ test.describe('GUI redesign: Modes planning surface', () => {
   await expect(main.getByText('Transition Preview', { exact: true })).toBeVisible();
   await expect(main.getByText('Current mode:')).toBeVisible();
   await expect(main.getByText('Configured modes:')).toBeVisible();
-  await expect(main.getByText('daily', { exact: true })).toBeVisible();
+  await expect(main.getByText('daily', { exact: true }).first()).toBeVisible();
 
   await main.getByRole('button', { name: /Work/ }).click();
   await expect(main.getByText('important_only')).toBeVisible();
@@ -22,6 +22,9 @@ test.describe('GUI redesign: Modes planning surface', () => {
   await main.getByRole('button', { name: /Streaming/ }).click();
   await expect(main.getByText('stream_safe')).toBeVisible();
   await expect(main.getByText('start obs').last()).toBeVisible();
+  await expect(main.getByText('Dry-run plan', { exact: true })).toBeVisible();
+  await expect(main.getByText('daily').first()).toBeVisible();
+  await expect(main.getByText('streaming').last()).toBeVisible();
   await expect(main.getByRole('button', { name: 'Transit' })).toBeEnabled();
   await main.getByRole('button', { name: 'Transit' }).click();
   await expect(main.getByText('Current mode:')).toBeVisible();

--- a/gui/tests/e2e/modes-planning.spec.ts
+++ b/gui/tests/e2e/modes-planning.spec.ts
@@ -21,8 +21,10 @@ test.describe('GUI redesign: Modes planning surface', () => {
 
   await main.getByRole('button', { name: /Streaming/ }).click();
   await expect(main.getByText('stream_safe')).toBeVisible();
-  await expect(main.getByText('start obs').last()).toBeVisible();
   await expect(main.getByText('Dry-run plan', { exact: true })).toBeVisible();
+  await expect(main.getByText('Flowgraph desired state')).toBeVisible();
+  await expect(main.getByText('Managed App desired state')).toBeVisible();
+  await expect(main.getByText('No managed app changes.')).toBeVisible();
   await expect(main.getByText('daily').first()).toBeVisible();
   await expect(main.getByText('streaming').last()).toBeVisible();
   await expect(main.getByRole('button', { name: 'Transit' })).toBeEnabled();

--- a/gui/tests/e2e/modes-planning.spec.ts
+++ b/gui/tests/e2e/modes-planning.spec.ts
@@ -29,6 +29,8 @@ test.describe('GUI redesign: Modes planning surface', () => {
   await expect(main.getByText('streaming').last()).toBeVisible();
   await expect(main.getByRole('button', { name: 'Transit' })).toBeEnabled();
   await main.getByRole('button', { name: 'Transit' }).click();
+  await expect(main.getByText('Transition Progress')).toBeVisible();
+  await expect(main.getByText(/completed|applying|firing|suppressing/)).toBeVisible();
   await expect(main.getByText('Current mode:')).toBeVisible();
   await expect(main.getByRole('button', { name: 'Current mode' })).toBeDisabled();
  });

--- a/gui/tests/e2e/modes-planning.spec.ts
+++ b/gui/tests/e2e/modes-planning.spec.ts
@@ -13,15 +13,18 @@ test.describe('GUI redesign: Modes planning surface', () => {
   await expect(main.getByText('Transition Preview', { exact: true })).toBeVisible();
   await expect(main.getByText('Current mode:')).toBeVisible();
   await expect(main.getByText('Configured modes:')).toBeVisible();
-  await expect(main.getByRole('button', { name: 'Configure mode first' })).toBeDisabled();
+  await expect(main.getByText('daily', { exact: true })).toBeVisible();
 
-  await main.getByRole('button', { name: /Sleep/ }).click();
-  await expect(main.getByText('critical_only')).toBeVisible();
-  await expect(main.getByText('emergency_alerts').last()).toBeVisible();
+  await main.getByRole('button', { name: /Work/ }).click();
+  await expect(main.getByText('important_only')).toBeVisible();
   await expect(main.getByRole('button', { name: 'Configure mode first' })).toBeDisabled();
 
   await main.getByRole('button', { name: /Streaming/ }).click();
   await expect(main.getByText('stream_safe')).toBeVisible();
   await expect(main.getByText('start obs').last()).toBeVisible();
+  await expect(main.getByRole('button', { name: 'Transit' })).toBeEnabled();
+  await main.getByRole('button', { name: 'Transit' }).click();
+  await expect(main.getByText('Current mode:')).toBeVisible();
+  await expect(main.getByRole('button', { name: 'Current mode' })).toBeDisabled();
  });
 });

--- a/gui/tests/e2e/now-dashboard.spec.ts
+++ b/gui/tests/e2e/now-dashboard.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+import { tokenQuery } from './fixtures';
+
+test.describe('GUI redesign: Now dashboard', () => {
+ test('Now is the first screen and shows runtime summary cards', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}`);
+
+  await expect(page.getByRole('heading', { name: 'Now' })).toBeVisible({
+   timeout: 15_000,
+  });
+  const main = page.getByRole('main');
+  await expect(main.getByText('Runtime cockpit')).toBeVisible();
+
+  await expect(main.getByText('Connection')).toBeVisible();
+  await expect(main.getByText('AI', { exact: true })).toBeVisible();
+  await expect(main.getByText('Managed Apps')).toBeVisible();
+  await expect(main.getByText('Flowgraph', { exact: true })).toBeVisible();
+
+  await expect(main.getByText('Runtime', { exact: true })).toBeVisible();
+  await expect(main.getByText('Recent Events')).toBeVisible();
+ });
+});

--- a/gui/tests/e2e/now-dashboard.spec.ts
+++ b/gui/tests/e2e/now-dashboard.spec.ts
@@ -13,6 +13,7 @@ test.describe('GUI redesign: Now dashboard', () => {
   await expect(main.getByText('Runtime cockpit')).toBeVisible();
 
   await expect(main.getByText('Connection')).toBeVisible();
+  await expect(main.getByText('Mode', { exact: true }).first()).toBeVisible();
   await expect(main.getByText('AI', { exact: true })).toBeVisible();
   await expect(main.getByText('Managed Apps').first()).toBeVisible();
   await expect(main.getByText('Flowgraph', { exact: true })).toBeVisible();
@@ -23,9 +24,13 @@ test.describe('GUI redesign: Now dashboard', () => {
  });
 
  test('Now quick actions navigate to operational surfaces', async ({ page }) => {
-  await page.goto(`/gui/${tokenQuery()}`);
-  const main = page.getByRole('main');
+ await page.goto(`/gui/${tokenQuery()}`);
+ const main = page.getByRole('main');
 
+  await main.getByRole('button', { name: 'manage' }).click();
+  await expect(page.getByRole('heading', { name: 'Modes' })).toBeVisible({ timeout: 15_000 });
+
+  await page.getByRole('navigation', { name: 'Main tabs' }).getByRole('button', { name: 'Now' }).click();
   await main.getByRole('button', { name: 'Flowgraph Studio' }).click();
   await expect(page.getByText('root =')).toBeVisible({ timeout: 15_000 });
 

--- a/gui/tests/e2e/now-dashboard.spec.ts
+++ b/gui/tests/e2e/now-dashboard.spec.ts
@@ -14,10 +14,25 @@ test.describe('GUI redesign: Now dashboard', () => {
 
   await expect(main.getByText('Connection')).toBeVisible();
   await expect(main.getByText('AI', { exact: true })).toBeVisible();
-  await expect(main.getByText('Managed Apps')).toBeVisible();
+  await expect(main.getByText('Managed Apps').first()).toBeVisible();
   await expect(main.getByText('Flowgraph', { exact: true })).toBeVisible();
 
   await expect(main.getByText('Runtime', { exact: true })).toBeVisible();
+  await expect(main.getByText('Flowgraph Problems')).toBeVisible();
   await expect(main.getByText('Recent Events')).toBeVisible();
+ });
+
+ test('Now quick actions navigate to operational surfaces', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}`);
+  const main = page.getByRole('main');
+
+  await main.getByRole('button', { name: 'Flowgraph Studio' }).click();
+  await expect(page.getByText('root =')).toBeVisible({ timeout: 15_000 });
+
+  await page.getByRole('navigation', { name: 'Main tabs' }).getByRole('button', { name: 'Now' }).click();
+  await main.getByRole('button', { name: 'Resources' }).click();
+  await expect(page.getByRole('heading', { name: '連携アプリ設定（run_with）' })).toBeVisible({
+   timeout: 15_000,
+  });
  });
 });

--- a/gui/tests/e2e/observability-layout.spec.ts
+++ b/gui/tests/e2e/observability-layout.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+import { tokenQuery } from './fixtures';
+
+test.describe('GUI redesign: Observability layout', () => {
+ test('Observability presents snapshot and event timeline as operational evidence', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}#observability`);
+
+  await expect(page.getByRole('heading', { name: 'Observability' })).toBeVisible({
+   timeout: 15_000,
+  });
+
+  const main = page.getByRole('main');
+  await expect(main.getByText('Runtime snapshot, live event timeline, and operational evidence.')).toBeVisible();
+  await expect(main.getByText('Snapshot', { exact: true })).toBeVisible();
+  await expect(main.getByText('Timeline', { exact: true })).toBeVisible();
+  await expect(main.getByText('Filters', { exact: true })).toBeVisible();
+  await expect(main.getByRole('button', { name: 'channel_datum' })).toBeVisible();
+  await expect(main.getByRole('button', { name: 'flowgraph_reloaded' })).toBeVisible();
+ });
+});

--- a/gui/tests/e2e/observability-layout.spec.ts
+++ b/gui/tests/e2e/observability-layout.spec.ts
@@ -17,5 +17,7 @@ test.describe('GUI redesign: Observability layout', () => {
   await expect(main.getByText('Filters', { exact: true })).toBeVisible();
   await expect(main.getByRole('button', { name: 'channel_datum' })).toBeVisible();
   await expect(main.getByRole('button', { name: 'flowgraph_reloaded' })).toBeVisible();
+  await expect(main.getByRole('heading', { name: 'Event History' })).toBeVisible();
+  await expect(main.getByText('Server-side ring buffer for operational evidence.')).toBeVisible();
  });
 });

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -54,9 +54,49 @@ const AI_OBSERVATION_CHANNEL_CAPACITY: usize = 1024;
 /// Control API WebSocket (`/api/v1/control/events`) 用のイベント配信キャパシティ。
 /// 接続されている GUI が遅い場合に `Lagged` 通知で補足するため、こちらも余裕をもって取る。
 const CONTROL_EVENT_CHANNEL_CAPACITY: usize = 2048;
+const CONTROL_EVENT_HISTORY_CAPACITY: usize = 512;
 /// δ-9 Part E: Flowgraph の `channel.subscribe` ingress が購読する `ChannelDatum` ブロードキャストの容量。
 /// 複数 bridge が独立して受信するため、遅い購読者がいても後続を取りこぼさないよう広めに取る。
 const CHANNEL_DATUM_BROADCAST_CAPACITY: usize = 2048;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TimestampedControlEvent {
+	pub at: String,
+	pub event: ControlEvent,
+}
+
+fn spawn_control_event_history_recorder(
+	mut rx: broadcast::Receiver<ControlEvent>,
+	history: Arc<RwLock<VecDeque<TimestampedControlEvent>>>,
+) {
+	tokio::spawn(async move {
+		loop {
+			match rx.recv().await {
+				Ok(event) => {
+					let mut h = history.write().await;
+					if h.len() >= CONTROL_EVENT_HISTORY_CAPACITY {
+						h.pop_front();
+					}
+					h.push_back(TimestampedControlEvent {
+						at: crate::datetime::DateTime::now().to_rfc3339(),
+						event,
+					});
+				}
+				Err(broadcast::error::RecvError::Lagged(dropped)) => {
+					let mut h = history.write().await;
+					if h.len() >= CONTROL_EVENT_HISTORY_CAPACITY {
+						h.pop_front();
+					}
+					h.push_back(TimestampedControlEvent {
+						at: crate::datetime::DateTime::now().to_rfc3339(),
+						event: ControlEvent::Lagged { dropped },
+					});
+				}
+				Err(broadcast::error::RecvError::Closed) => break,
+			}
+		}
+	});
+}
 
 /// `respect_speech_floor` が設定されているとき、対応する speech floor が空くまで非同期待機する（スキップしない）。
 pub async fn wait_respect_speech_floor_key(state: &SharedState, key: Option<&str>) {
@@ -119,6 +159,7 @@ pub struct State {
 	/// Control API WebSocket の配信チャネル（Phase VI-α-3）。
 	/// 各 WS 接続が `subscribe()` で受信側を作り、切断で drop する使い方。受信者 0 でも `send()` は失敗しない設計にする。
 	pub control_event_tx: broadcast::Sender<ControlEvent>,
+	pub control_event_history: Arc<RwLock<VecDeque<TimestampedControlEvent>>>,
 	/// δ-9 Part E: `push_channel_datum` / `push_channel_datum_quiet` / `finalize_channel_datum_and_dispatch`
 	/// で `ChannelDatum` を配信するブロードキャスト送信側。
 	///
@@ -204,6 +245,7 @@ impl State {
 
 		let (ai_observation_tx, _rx) = broadcast::channel::<Observation>(AI_OBSERVATION_CHANNEL_CAPACITY);
 		let (control_event_tx, _rx) = broadcast::channel::<ControlEvent>(CONTROL_EVENT_CHANNEL_CAPACITY);
+		let control_event_history = Arc::new(RwLock::new(VecDeque::with_capacity(CONTROL_EVENT_HISTORY_CAPACITY)));
 		let (channel_datum_tx, _rx) = broadcast::channel::<ChannelDatum>(CHANNEL_DATUM_BROADCAST_CAPACITY);
 
 		let twitch_snapshot = conf.twitch.as_ref().map(|t| Arc::new(t.clone()));
@@ -250,7 +292,8 @@ impl State {
 			libretranslate: crate::libretranslate::runtime_new(),
 			runtime_paths,
 			ai_observation_tx,
-			control_event_tx,
+			control_event_tx: control_event_tx.clone(),
+			control_event_history: control_event_history.clone(),
 			channel_datum_tx,
 			twitch: twitch_snapshot,
 			twitch_oauth: OAuthSessions::new(),
@@ -265,6 +308,7 @@ impl State {
 			shutdown,
 			runtime_mode_transition_busy: Arc::new(AtomicBool::new(false)),
 		}));
+		spawn_control_event_history_recorder(control_event_tx.subscribe(), control_event_history);
 		log::trace!("State の生成が完了しました。");
 
 		// Phase δ-9 D.2/D.3 (v1.0): V1 `[[processors]]` は全廃。`conf.processors` が残っていても warning を出すだけ。

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,7 +13,9 @@ mod speech_floor;
 
 pub use channel_attach::{Attachment, DataSource};
 pub use runtime_mode_apply::{apply_runtime_mode_change, ApplyRuntimeModeError};
-pub use runtime_mode_transition::{apply_runtime_mode_transition_full, try_begin_runtime_mode_transition};
+pub use runtime_mode_transition::{
+	apply_runtime_mode_transition_full, try_begin_runtime_mode_transition, RuntimeModeTransitionStatus,
+};
 pub use channel_datum::{ChannelData, ChannelDatum, SharedChannelData};
 pub use speech_floor::SpeechFloorManager;
 
@@ -231,6 +233,7 @@ pub struct State {
 	/// RM-5: `apply_runtime_mode_transition_full` が Managed App I/O 等を実行している間 true。
 	/// 再入の `try_begin_runtime_mode_transition` は失敗させる。
 	pub runtime_mode_transition_busy: Arc<AtomicBool>,
+	pub runtime_mode_transition_status: Arc<RwLock<RuntimeModeTransitionStatus>>,
 }
 
 impl State {
@@ -307,6 +310,7 @@ impl State {
 			voicepeak_fallback_exe,
 			shutdown,
 			runtime_mode_transition_busy: Arc::new(AtomicBool::new(false)),
+			runtime_mode_transition_status: Arc::new(RwLock::new(RuntimeModeTransitionStatus::idle())),
 		}));
 		spawn_control_event_history_recorder(control_event_tx.subscribe(), control_event_history);
 		log::trace!("State の生成が完了しました。");

--- a/src/state/runtime_mode_transition.rs
+++ b/src/state/runtime_mode_transition.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crate::conf::Conf;
+use crate::conf::{Conf, ModeTransitionPlan};
 use crate::control_events::ControlEvent;
 use crate::flowgraph::activation::TriggerGate;
 use crate::flowgraph::node::{PortDirection, TriggerEvent};
@@ -35,6 +35,124 @@ pub async fn try_begin_runtime_mode_transition(state: &SharedState) -> Option<Tr
 }
 
 /// `apply_runtime_mode_change` に続く follow-up（Managed App 適用結果）をまとめた戻り値。
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeModeTransitionPhase {
+	Idle,
+	Planning,
+	SuppressingFlowgraph,
+	ApplyingMode,
+	ApplyingManagedApps,
+	FiringFlowgraphHook,
+	Completed,
+	Failed,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuntimeModeTransitionStatus {
+	pub seq: u64,
+	pub active: bool,
+	pub phase: RuntimeModeTransitionPhase,
+	pub step_index: usize,
+	pub step_count: usize,
+	pub message: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub started_at: Option<String>,
+	pub updated_at: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub finished_at: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub error: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub plan: Option<ModeTransitionPlan>,
+	#[serde(default)]
+	pub managed_apps: Vec<crate::control_events::RuntimeModeManagedAppOp>,
+}
+
+impl RuntimeModeTransitionStatus {
+	pub fn idle() -> Self {
+		let now = crate::datetime::DateTime::now().to_rfc3339();
+		Self {
+			seq: 0,
+			active: false,
+			phase: RuntimeModeTransitionPhase::Idle,
+			step_index: 0,
+			step_count: 0,
+			message: "idle".into(),
+			started_at: None,
+			updated_at: now,
+			finished_at: None,
+			error: None,
+			plan: None,
+			managed_apps: Vec::new(),
+		}
+	}
+}
+
+async fn begin_transition_status(state: &SharedState, plan: ModeTransitionPlan) -> u64 {
+	let progress = state.read().await.runtime_mode_transition_status.clone();
+	let now = crate::datetime::DateTime::now().to_rfc3339();
+	let mut status = progress.write().await;
+	let seq = status.seq.saturating_add(1);
+	*status = RuntimeModeTransitionStatus {
+		seq,
+		active: true,
+		phase: RuntimeModeTransitionPhase::Planning,
+		step_index: 1,
+		step_count: 5,
+		message: "transition accepted".into(),
+		started_at: Some(now.clone()),
+		updated_at: now,
+		finished_at: None,
+		error: None,
+		plan: Some(plan),
+		managed_apps: Vec::new(),
+	};
+	seq
+}
+
+async fn set_transition_status(
+	state: &SharedState,
+	seq: u64,
+	phase: RuntimeModeTransitionPhase,
+	step_index: usize,
+	message: impl Into<String>,
+) {
+	let progress = state.read().await.runtime_mode_transition_status.clone();
+	let mut status = progress.write().await;
+	if status.seq != seq {
+		return;
+	}
+	status.phase = phase;
+	status.step_index = step_index;
+	status.message = message.into();
+	status.updated_at = crate::datetime::DateTime::now().to_rfc3339();
+}
+
+async fn finish_transition_status(
+	state: &SharedState,
+	seq: u64,
+	phase: RuntimeModeTransitionPhase,
+	message: impl Into<String>,
+	error: Option<String>,
+	managed_apps: Vec<crate::control_events::RuntimeModeManagedAppOp>,
+) {
+	let progress = state.read().await.runtime_mode_transition_status.clone();
+	let now = crate::datetime::DateTime::now().to_rfc3339();
+	let mut status = progress.write().await;
+	if status.seq != seq {
+		return;
+	}
+	status.active = false;
+	status.phase = phase;
+	status.step_index = status.step_count;
+	status.message = message.into();
+	status.updated_at = now.clone();
+	status.finished_at = Some(now);
+	status.error = error;
+	status.managed_apps = managed_apps;
+}
+
 #[derive(Debug, Clone)]
 pub struct RuntimeModeTransitionOutcome {
 	pub applied: AppliedRuntimeMode,
@@ -139,8 +257,16 @@ pub async fn apply_runtime_mode_transition_full(
 		let s = state.read().await;
 		s.runtime_mode_id.read().ok().and_then(|g| g.clone())
 	};
-	let will_mutate = match crate::conf::build_mode_transition_plan(conf, current_slot.as_deref(), normalized.as_deref()) {
-		Ok(p) => !p.noop,
+	let (will_mutate, status_seq) = match crate::conf::build_mode_transition_plan(conf, current_slot.as_deref(), normalized.as_deref()) {
+		Ok(p) => {
+			let will_mutate = !p.noop;
+			let status_seq = if will_mutate {
+				begin_transition_status(state, p).await
+			} else {
+				0
+			};
+			(will_mutate, status_seq)
+		}
 		Err(msg) => return Err(ApplyRuntimeModeError::PlanFailed(msg)),
 	};
 
@@ -151,6 +277,14 @@ pub async fn apply_runtime_mode_transition_full(
 	};
 
 	let _global_suppress = if will_mutate {
+		set_transition_status(
+			state,
+			status_seq,
+			RuntimeModeTransitionPhase::SuppressingFlowgraph,
+			2,
+			"suppressing flowgraph exec triggers",
+		)
+		.await;
 		gate_for_guard.map(|g| {
 			g.set_global_exec_suppress(true);
 			log::debug!("《RuntimeMode》 TriggerGate global_exec_suppress=ON（遷移開始）");
@@ -160,11 +294,45 @@ pub async fn apply_runtime_mode_transition_full(
 		None
 	};
 
-	let applied = apply_runtime_mode_change(state, conf, normalized, reason).await?;
+	if will_mutate {
+		set_transition_status(
+			state,
+			status_seq,
+			RuntimeModeTransitionPhase::ApplyingMode,
+			3,
+			"applying runtime mode slot",
+		)
+		.await;
+	}
+	let applied = match apply_runtime_mode_change(state, conf, normalized, reason).await {
+		Ok(applied) => applied,
+		Err(e) => {
+			if will_mutate {
+				finish_transition_status(
+					state,
+					status_seq,
+					RuntimeModeTransitionPhase::Failed,
+					"runtime mode transition failed",
+					Some(e.to_string()),
+					Vec::new(),
+				)
+				.await;
+			}
+			return Err(e);
+		}
+	};
 	let mut managed_reports = Vec::new();
 
 	if !applied.noop {
 		if !conf.modes.is_empty() {
+			set_transition_status(
+				state,
+				status_seq,
+				RuntimeModeTransitionPhase::ApplyingManagedApps,
+				4,
+				"applying managed app desired state",
+			)
+			.await;
 			let def = conf
 				.modes
 				.get(applied.current_effective_id.as_str())
@@ -188,7 +356,27 @@ pub async fn apply_runtime_mode_transition_full(
 	}
 
 	if !applied.noop {
+		set_transition_status(
+			state,
+			status_seq,
+			RuntimeModeTransitionPhase::FiringFlowgraphHook,
+			5,
+			"firing runtime mode flowgraph hook",
+		)
+		.await;
 		fire_runtime_mode_changed_flowgraph_hook(state, conf, &applied).await;
+	}
+
+	if !applied.noop {
+		finish_transition_status(
+			state,
+			status_seq,
+			RuntimeModeTransitionPhase::Completed,
+			"runtime mode transition completed",
+			None,
+			managed_reports.clone(),
+		)
+		.await;
 	}
 
 	Ok(RuntimeModeTransitionOutcome {

--- a/src/web_interface/control/events.rs
+++ b/src/web_interface/control/events.rs
@@ -3,3 +3,61 @@
 //! 型の定義本体は [`crate::control_events`]（`state` が `web_interface` に依存しないための配置）。
 
 pub use crate::control_events::{ChannelDatumPhase, ControlEvent, ProcessorInvocationOutcome};
+
+use actix_web::web::{Data, Query};
+use actix_web::{get, HttpResponse, Responder};
+use serde::Deserialize;
+
+use crate::SharedState;
+
+#[derive(Debug, Deserialize)]
+pub struct EventHistoryQuery {
+	#[serde(default = "default_limit")]
+	pub limit: usize,
+	pub kind: Option<String>,
+}
+
+fn default_limit() -> usize {
+	100
+}
+
+#[get("/events/history")]
+pub async fn history(state: Data<SharedState>, query: Query<EventHistoryQuery>) -> impl Responder {
+	let limit = query.limit.clamp(1, 500);
+	let kind = query.kind.as_deref().map(str::trim).filter(|s| !s.is_empty());
+	let history = {
+		let s = state.read().await;
+		s.control_event_history.clone()
+	};
+	let h = history.read().await;
+	let mut rows: Vec<_> = h
+		.iter()
+		.rev()
+		.filter(|item| kind.map(|k| control_event_kind(&item.event) == k).unwrap_or(true))
+		.take(limit)
+		.cloned()
+		.collect();
+	rows.reverse();
+	HttpResponse::Ok().json(serde_json::json!({
+		"events": rows,
+		"limit": limit,
+	}))
+}
+
+fn control_event_kind(ev: &ControlEvent) -> &'static str {
+	match ev {
+		ControlEvent::ChannelDatum { .. } => "channel_datum",
+		ControlEvent::Lagged { .. } => "lagged",
+		ControlEvent::Heartbeat { .. } => "heartbeat",
+		ControlEvent::PauseState { .. } => "pause_state",
+		ControlEvent::Reloaded { .. } => "reloaded",
+		ControlEvent::ProcessorInvoked { .. } => "processor_invoked",
+		ControlEvent::Restarting { .. } => "restarting",
+		ControlEvent::FlowgraphReloaded { .. } => "flowgraph_reloaded",
+		ControlEvent::ManagedAppState { .. } => "managed_app_state",
+		ControlEvent::RestartRecommended { .. } => "restart_recommended",
+		ControlEvent::RuntimeModeChanged { .. } => "runtime_mode_changed",
+		ControlEvent::RuntimeModeManagedApps { .. } => "runtime_mode_managed_apps",
+		ControlEvent::OAuthStatus { .. } => "oauth_status",
+	}
+}

--- a/src/web_interface/control/mod.rs
+++ b/src/web_interface/control/mod.rs
@@ -47,6 +47,7 @@ pub fn register(cfg: &mut web::ServiceConfig) {
 			.service(ping::ping)
 			.service(ping::whoami)
 			.service(ws::events_ws)
+			.service(events::history)
 			.configure(actions::configure)
 			.configure(reload::configure)
 			.configure(restart::configure)

--- a/src/web_interface/control/modes.rs
+++ b/src/web_interface/control/modes.rs
@@ -54,6 +54,16 @@ pub struct TransitResponse {
 	pub managed_apps: Option<Vec<RuntimeModeManagedAppOp>>,
 }
 
+#[get("/modes/transition")]
+pub async fn get_modes_transition(state: Data<SharedState>) -> impl Responder {
+	let progress = {
+		let s = state.read().await;
+		s.runtime_mode_transition_status.clone()
+	};
+	let status = progress.read().await.clone();
+	HttpResponse::Ok().json(status)
+}
+
 fn http_response_for_apply_runtime_mode_error(e: ApplyRuntimeModeError) -> HttpResponse {
 	match e {
 		ApplyRuntimeModeError::PlanFailed(msg) => HttpResponse::BadRequest().json(serde_json::json!({
@@ -295,6 +305,7 @@ pub async fn post_modes_transit(state: Data<SharedState>, body: Json<TransitBody
 pub fn configure(cfg: &mut actix_web::web::ServiceConfig) {
 	cfg.service(get_modes_list)
 		.service(get_current_mode)
+		.service(get_modes_transition)
 		.service(put_current_mode)
 		.service(post_modes_plan)
 		.service(post_modes_transit);


### PR DESCRIPTION
﻿## Summary

This PR implements the GUI runtime cockpit work on top of `v2`.

- Reworks the GUI shell into operational tabs for Now, Modes, Flowgraph Studio, Resources, Observability, Settings, and legacy surfaces.
- Adds Runtime Mode planning/transit UI, backend-backed transition progress state, and `/api/v1/control/modes/transition`.
- Expands Flowgraph Studio with resizable panes, searchable command palette/node insert, multi-select, undo/redo, duplicate, align, distribute, group-layout, and delete operations.
- Adds Observability event history backed by a server-side ControlEvent ring buffer and `/api/v1/control/events/history`.
- Updates GUI redesign roadmap documentation to match the implemented state.
- Adds/updates Playwright coverage for shell navigation, Now, Modes, Flowgraph Studio, and Observability surfaces.

## Validation

- `cargo check`
- `npm run check`
- `npm run build`
- `npm run test:e2e -- control-panel-smoke.spec.ts now-dashboard.spec.ts main-navigation.spec.ts modes-planning.spec.ts flowgraph-studio-layout.spec.ts observability-layout.spec.ts`
- `npm run test:e2e -- modes-planning.spec.ts`

## Notes

`cargo check` still reports existing unused/dead-code warnings outside this PR's GUI/runtime-mode scope. `cargo fmt --check` is not a useful gate yet because the repository currently has broad pre-existing newline-style differences on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a broad GUI information-architecture rewrite plus new Control API endpoints/state for runtime-mode transition progress and server-side event history that affect operational flows.
> 
> **Overview**
> Reworks the GUI shell into a **runtime cockpit** with a new top-level navigation model (`Now`, `Modes`, `Flowgraph Studio`, `Resources`, `Observability`, `Settings`) and legacy hash fallbacks to preserve deep links.
> 
> Adds new operational surfaces: a `Now` dashboard that aggregates snapshot/mode/managed-app/flowgraph health, a `Modes` UI that plans and executes runtime-mode transitions (including progress polling via new `/modes/transition`), and an `Observability` layout that now includes server-side event history.
> 
> Enhances Flowgraph authoring with IDE-style layout + resizable panes, a searchable command palette (including node insert), multi-select, and an undo/redo + layout command model in `flowgraphStore`.
> 
> Extends the Control API with `/events/history` backed by an in-memory ring buffer recorder, and wires additional runtime-mode/restart event kinds through the GUI event stream. Updates E2E fixture/runtime modes and adds Playwright coverage for the redesigned navigation and new screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3041506827a593046f88df059d1ef570c3b086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->