### PR TITLE
[codex] Establish v2 health baseline

### DIFF
--- a/docs/maintenance/health-baseline-2026-04-27.md
+++ b/docs/maintenance/health-baseline-2026-04-27.md
@@ -1,0 +1,92 @@
+# Health Baseline - 2026-04-27
+
+This document captures the v2 maintenance baseline before dependency updates and broader structural cleanup.
+
+## Scope
+
+- Establish the current check status.
+- Fix low-risk lint/check issues that do not change behavior.
+- Record dependency update candidates without changing lockfiles.
+- Keep dependency upgrades and larger refactors for follow-up PRs.
+
+## Check Status
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `cargo check` | Passes with 19 warnings | Two unused imports in `flowgraph/quantity/parser.rs` were removed in this PR. Remaining warnings are dead code or intentionally unused API/test helpers. |
+| `cargo fmt --check` | Fails | Broad existing Windows newline-style mismatch plus rustfmt diffs across many files. Treat as a dedicated line-ending/format policy PR, not as incidental churn. |
+| `cargo clippy --all-targets --all-features -- -D warnings` | Fails | Current baseline reports many existing warnings, including dead code, test lint nits, doc indentation, and some complexity/style lints. Do not enable as a hard gate yet. |
+| `npm run check` | Passes | Svelte and TypeScript checks are clean. |
+| `npm run lint` | Passes | Fixed keyed each blocks, a DOM listener type issue, one useless mustache interpolation, Svelte reactive collection lint issues, and stale eslint-disable comments. |
+| `npm audit --audit-level=moderate` | Passes | 0 vulnerabilities. |
+
+## Rust Warning Baseline
+
+`cargo check` still reports 19 warnings after this PR:
+
+- OpenAI Responses client/testing helpers that are not currently used by production code.
+- Streaming response fields that are preserved for protocol completeness but not yet read by consumers.
+- A few dormant helper functions or fields in motion, VoiceVox, Twitch OAuth, shutdown, and GUI path handling.
+
+Recommendation: do not delete these in bulk. Either wire them into planned features, move test-only helpers under `#[cfg(test)]`, or add narrow `#[allow(dead_code)]` with rationale when the API is intentionally reserved.
+
+## Clippy Baseline
+
+`cargo clippy --all-targets --all-features -- -D warnings` is not ready as a required gate. The highest-signal groups are:
+
+- Safe mechanical fixes: inconsistent digit grouping, `div_ceil`, `as_deref`, `first()`, bool asserts, `is_empty`, needless borrows, redundant closures.
+- Intentional design exceptions: long argument lists, complex types, methods named `to_*` that consume self.
+- Test-only cleanup: field reassignment after default, approximate constants, items after test modules.
+- Documentation formatting: lazy continuation indentation in rustdoc comments.
+- Dead code policy: response protocol fields and reserved helpers.
+
+Recommendation: introduce clippy gradually. Start with mechanical test/lint fixes, then decide which lints are policy and which are allowed.
+
+## Dependency Baseline
+
+### Rust
+
+`cargo update --dry-run --verbose` reports no lockfile updates under current semver constraints. It also reports these newer versions outside current constraints:
+
+| Crate | Current | Available | Notes |
+| --- | --- | --- | --- |
+| `async-openai` | 0.34.0 | 0.36.1 | Review API compatibility separately. |
+| `generic-array` | 0.14.7 | 0.14.9 | Transitive. |
+| `sha2` | 0.10.9 | 0.11.0 | Major/minor constraint change. |
+| `tokio-tungstenite` | 0.26.2 | 0.29.0 | WebSocket stack, test carefully. |
+| `toml_edit` | 0.23.10 | 0.25.11 | TOML mutation paths need regression tests. |
+| `ureq` | 2.12.1 | 3.3.0 | Transitive. |
+| `zip` | 2.4.2 | 8.6.0 | Major jump; isolate if updated. |
+
+### GUI
+
+`npm outdated` reports patch/minor update candidates:
+
+| Package | Current | Wanted | Latest |
+| --- | --- | --- | --- |
+| `@rolldown/binding-win32-x64-msvc` | 1.0.0-rc.16 | 1.0.0-rc.17 | 1.0.0-rc.17 |
+| `@tailwindcss/vite` | 4.2.2 | 4.2.4 | 4.2.4 |
+| `@types/node` | 24.12.2 | 24.12.2 | 25.6.0 |
+| `eslint-plugin-svelte` | 3.17.0 | 3.17.1 | 3.17.1 |
+| `svelte` | 5.55.4 | 5.55.5 | 5.55.5 |
+| `tailwindcss` | 4.2.2 | 4.2.4 | 4.2.4 |
+| `typescript-eslint` | 8.58.2 | 8.59.0 | 8.59.0 |
+| `vite` | 8.0.8 | 8.0.10 | 8.0.10 |
+
+Recommendation: update GUI patch/minor dependencies first in the dependency-update PR, keep `@types/node` major separate unless needed.
+
+## Follow-up PR Order
+
+1. Dependency update PR:
+   - GUI patch/minor updates first.
+   - Rust updates only where semver-compatible or clearly scoped.
+   - Run `cargo check`, `npm run check`, `npm run lint`, `npm run build`, and focused Playwright smoke tests.
+
+2. Structure cleanup PR:
+   - Consolidate GUI API/type/store boundaries.
+   - Review `web_interface/control/*` module naming after the v2 split.
+   - Remove or justify dead code once the dependency update branch is stable.
+
+3. Format policy PR:
+   - Decide repository line-ending policy for Rust sources.
+   - Apply rustfmt only when the line-ending churn is intentional and isolated.

--- a/gui/src/lib/EventHistoryPanel.svelte
+++ b/gui/src/lib/EventHistoryPanel.svelte
@@ -101,7 +101,7 @@
   <div class="px-3 py-6 text-center text-sm opacity-60">No event history yet.</div>
  {:else}
   <ol class="max-h-72 overflow-y-auto">
-   {#each filtered.toReversed() as item}
+   {#each filtered.toReversed() as item (`${item.at}:${item.event.kind}:${summarize(item.event)}`)}
     <li class="border-b border-surface-200-800 px-3 py-2 last:border-b-0">
      <div class="flex items-center gap-2 text-[11px] opacity-60">
       <span>{new Date(item.at).toLocaleString()}</span>

--- a/gui/src/lib/ReloadPanel.svelte
+++ b/gui/src/lib/ReloadPanel.svelte
@@ -31,6 +31,7 @@
  // Reload 成功時、サーバから `ControlEvent.reloaded` が飛んでくるので SnapshotView は自動追従する。
 
  import { onMount, onDestroy } from 'svelte';
+ import { SvelteMap } from 'svelte/reactivity';
  import { api } from './api';
  import {
   ControlApiError,
@@ -149,7 +150,7 @@ let openError = $state<string | null>(null);
 let openResult = $state<string | null>(null);
 
 const modifyProcessorById = $derived.by(() => {
- const map = new Map<string, ProcessorSummary>();
+ const map = new SvelteMap<string, ProcessorSummary>();
  for (const p of modifyProcessors) {
   if (p.id) map.set(p.id, p);
  }

--- a/gui/src/lib/control/dictionary/DictionaryLiveQuickAdd.svelte
+++ b/gui/src/lib/control/dictionary/DictionaryLiveQuickAdd.svelte
@@ -254,7 +254,7 @@
  {#if quickAddTables.length === 0}
   <p class="opacity-70">
    <code>[[control_api.tables]]</code> に
-   <code>quick_add = {'{'} node_id = &quot;...&quot; {'}'}</code>
+   <code>quick_add = &#123; node_id = &quot;...&quot; &#125;</code>
    を指定した Table がありません。conf.toml を見直してください。
   </p>
  {:else if !selectedTable}

--- a/gui/src/lib/flowgraph/FlowgraphPalette.svelte
+++ b/gui/src/lib/flowgraph/FlowgraphPalette.svelte
@@ -8,6 +8,7 @@
   * - Phase ο-6: カテゴリ単位の表示/非表示（localStorage 永続化）、HTML5 DnD で feature を dataTransfer に載せる。
   */
  import { onMount } from 'svelte';
+ import { SvelteSet } from 'svelte/reactivity';
  import { flowgraphStore } from '../flowgraphStore.svelte';
  import type { FlowgraphNodeSpec } from '../types';
 
@@ -26,7 +27,7 @@
  );
 
  /** 非表示カテゴリ（`spec.category` 文字列キー）。 */
- let hiddenCategories = $state<Set<string>>(new Set());
+ const hiddenCategories = new SvelteSet<string>();
 
  onMount(() => {
   try {
@@ -34,7 +35,10 @@
    if (!raw) return;
    const arr = JSON.parse(raw) as unknown;
    if (Array.isArray(arr)) {
-    hiddenCategories = new Set(arr.filter((x): x is string => typeof x === 'string'));
+    hiddenCategories.clear();
+    for (const x of arr) {
+     if (typeof x === 'string') hiddenCategories.add(x);
+    }
    }
   } catch {
    /* ignore */
@@ -50,10 +54,8 @@
  }
 
  function toggleCategoryVisibility(category: string) {
-  const next = new Set(hiddenCategories);
-  if (next.has(category)) next.delete(category);
-  else next.add(category);
-  hiddenCategories = next;
+  if (hiddenCategories.has(category)) hiddenCategories.delete(category);
+  else hiddenCategories.add(category);
   persistHidden();
  }
 

--- a/gui/src/lib/flowgraph/FlowgraphPaneDropBridge.svelte
+++ b/gui/src/lib/flowgraph/FlowgraphPaneDropBridge.svelte
@@ -33,10 +33,10 @@
   };
 
   pane.addEventListener('dragover', onDragOver);
-  pane.addEventListener('drop', onDrop as EventListener);
+  pane.addEventListener('drop', onDrop);
   return () => {
    pane.removeEventListener('dragover', onDragOver);
-   pane.removeEventListener('drop', onDrop as EventListener);
+   pane.removeEventListener('drop', onDrop);
   };
  });
 </script>

--- a/gui/src/lib/flowgraph/FlowgraphPropertyEditor.svelte
+++ b/gui/src/lib/flowgraph/FlowgraphPropertyEditor.svelte
@@ -20,8 +20,10 @@
  }
 
  /** propName → parse エラーメッセージ（valid 時はキー無し） */
- let unitParseByProp = $state<Record<string, string>>({});
- const unitParseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+let unitParseByProp = $state<Record<string, string>>({});
+// Timer handles are imperative bookkeeping, not UI state.
+// eslint-disable-next-line svelte/prefer-svelte-reactivity
+const unitParseTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
  let prevSelectedNodeId = $state<string | null>(null);
  $effect(() => {

--- a/gui/src/lib/flowgraphStore.svelte.ts
+++ b/gui/src/lib/flowgraphStore.svelte.ts
@@ -281,6 +281,8 @@ class FlowgraphStore {
   const first = rows[0].position;
   const last = rows[rows.length - 1].position;
   const step = (axis === 'x' ? last[0] - first[0] : last[1] - first[1]) / (rows.length - 1);
+  // Local lookup for one layout command, not reactive UI state.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
   const positions = new Map<string, [number, number]>();
   rows.forEach((row, i) => {
    positions.set(

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -307,7 +307,7 @@
 
  <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
   <div class="grid gap-3 md:grid-cols-2">
-   {#each displayModes as mode}
+   {#each displayModes as mode (mode.id)}
     {@const selected = selectedMode?.id === mode.id}
     <button
      type="button"
@@ -323,7 +323,7 @@
      </div>
      <p class="mt-2 text-xs leading-relaxed opacity-70">{mode.description}</p>
      <div class="mt-3 flex flex-wrap gap-1">
-      {#each mode.flowgraphGroups.slice(0, 3) as group}
+      {#each mode.flowgraphGroups.slice(0, 3) as group (group)}
        <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-[10px]">{group}</code>
       {/each}
      </div>
@@ -354,7 +354,7 @@
       </dl>
      {:else}
       <div class="flex flex-wrap gap-1">
-       {#each selectedMode.flowgraphGroups as group}
+       {#each selectedMode.flowgraphGroups as group (group)}
         <code class="rounded bg-surface-100-900 px-1.5 py-0.5 text-xs">{group}</code>
        {/each}
       </div>
@@ -398,7 +398,7 @@
      <div class="mb-1 text-xs font-semibold opacity-70">Managed App desired state</div>
      {#if managedDesiredRows.length > 0}
       <dl class="grid grid-cols-[64px_minmax(0,1fr)] gap-x-2 gap-y-1 text-xs">
-       {#each managedDesiredRows as row}
+       {#each managedDesiredRows as row (row.label)}
         <dt class="opacity-60">{row.label}</dt>
         <dd class="truncate font-mono">{joinList(row.values)}</dd>
        {/each}
@@ -407,7 +407,7 @@
       <div class="rounded bg-surface-100-900 px-2 py-1 text-xs opacity-60">No managed app changes.</div>
      {:else}
       <ul class="grid gap-1">
-       {#each selectedMode.managedApps as action}
+       {#each selectedMode.managedApps as action (action)}
         <li class="rounded bg-surface-100-900 px-2 py-1 text-xs">{action}</li>
        {/each}
       </ul>
@@ -434,7 +434,7 @@
      <div>
       <div class="mb-1 text-xs font-semibold opacity-70">Last Managed App ops</div>
       <ul class="grid gap-1">
-       {#each managedAppOps as op}
+       {#each managedAppOps as op (`${op.op}:${op.id}:${op.ok}:${op.detail ?? ''}`)}
         <li class="rounded bg-surface-100-900 px-2 py-1 text-xs">
          <span class="font-mono">{op.op}</span>
          <span class="ml-1">{op.id}</span>

--- a/gui/tests/e2e/dictionary-editor-409-merge.spec.ts
+++ b/gui/tests/e2e/dictionary-editor-409-merge.spec.ts
@@ -121,9 +121,7 @@ test.describe('§3.3 dictionary-editor-409-merge', () => {
 		const preBody = (await preRes.json()) as TableDto;
 		const target = preBody.rows.find((row) => row.values.source === TARGET_SOURCE);
 		expect(target).toBeDefined();
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const targetRowIndex = target!.row_index;
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const targetValues = { ...target!.values, replacement: theirReplacement };
 
 		const extPatch = await request.patch(
@@ -189,7 +187,6 @@ test.describe('§3.3 dictionary-editor-409-merge', () => {
 				headers: { ...authHeader(), 'If-Match': `b3:${finalBody.content_hash}` },
 				data: {
 					values: {
-						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 						...finalRow!.values,
 						replacement: ORIGINAL_REPLACEMENT,
 					},

--- a/src/flowgraph/quantity/parser.rs
+++ b/src/flowgraph/quantity/parser.rs
@@ -21,10 +21,8 @@
 //!   `lookup_prefixable_base`; the unprefixed forms go through `lookup_derived`.
 //! - Parentheses are NOT supported in xi-1 (reserved for xi-2+).
 
-use std::collections::BTreeMap;
-
 use super::prefix::SIPrefix;
-use super::unit::{BaseUnitId, Unit};
+use super::unit::Unit;
 
 /// Errors produced while parsing a unit string.
 #[derive(Debug, Clone, thiserror::Error)]


### PR DESCRIPTION
﻿## Summary

This is the first maintenance PR in the v2 cleanup sequence. It establishes the current health baseline before dependency updates and broader structure cleanup.

- Adds `docs/maintenance/health-baseline-2026-04-27.md` with check results, warning/clippy baseline, and dependency update candidates.
- Removes two unused Rust imports from the quantity parser, reducing `cargo check` warnings from 21 to 19.
- Fixes low-risk GUI lint issues so `npm run lint` now passes.
- Leaves dependency updates and larger refactors for follow-up branches.

## Validation

- `cargo check` passes with 19 existing warnings.
- `cargo fmt --check` was inspected and still fails due to broad existing Windows newline-style/rustfmt churn; documented as a separate format policy task.
- `cargo clippy --all-targets --all-features -- -D warnings` was inspected and fails on the existing baseline; documented instead of enabling as a hard gate.
- `npm run check`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=moderate`
- `npm outdated`
- `cargo update --dry-run --verbose`

## Follow-up

After this is merged, the next planned branch is the dependency update PR. It should start with GUI patch/minor updates and avoid the `@types/node` major unless needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation plus mechanical lint/type fixes (keyed Svelte `each`, reactive collection types, event listener typing) and removal of unused Rust imports, with no intended runtime behavior changes.
> 
> **Overview**
> Adds a new maintenance baseline doc (`docs/maintenance/health-baseline-2026-04-27.md`) capturing current check/clippy/warning status and listing dependency update candidates without updating lockfiles.
> 
> Fixes low-risk GUI lint issues so `npm run lint` passes (adds stable keys to `{#each}` blocks, swaps reactive `Map`/`Set` usage to `SvelteMap`/`SvelteSet`, tightens DOM event listener typing, and removes/justifies a couple of eslint disables), plus a small HTML-escape tweak in dictionary UI copy.
> 
> Removes two unused imports in the Rust unit quantity parser (`src/flowgraph/quantity/parser.rs`) to reduce `cargo check` warnings, and cleans up unnecessary eslint-disable comments in the related Playwright e2e test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit addd97417f129bcb5668a8578bd7ad94474c722b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->