### PR TITLE
[codex] Clarify runtime mode and event boundaries

### DIFF
--- a/docs/maintenance/structure-cleanup-2026-04-27.md
+++ b/docs/maintenance/structure-cleanup-2026-04-27.md
@@ -1,0 +1,44 @@
+# Structure Cleanup - 2026-04-27
+
+This PR is the third maintenance slice after the health baseline and dependency refresh.
+
+## Scope
+
+- Keep behavior unchanged.
+- Move presentation-only Runtime Mode helpers out of the Svelte tab component.
+- Move ControlEvent kind classification from the web history endpoint to the event type itself.
+- Leave larger module reshapes for later branches.
+
+## Changes
+
+### GUI
+
+`gui/src/lib/tabs/ModesTab.svelte` now delegates pure display logic to `gui/src/lib/control/runtimeModes.ts`:
+
+- planned Runtime Mode card definitions
+- configured/custom mode display row construction
+- managed app desired-state row construction
+- Control API error formatting
+- list formatting
+
+The tab component remains responsible for UI state, polling, API calls, and rendering.
+
+### Control API
+
+`ControlEvent::kind()` now lives in `src/control_events.rs`. The event history endpoint uses that method for `kind` filtering instead of carrying a separate local match in `src/web_interface/control/events.rs`.
+
+This keeps event classification next to the event enum, so future event variants have one obvious place to update.
+
+## Deferred
+
+- Splitting `gui/src/lib/types.ts` into domain type files. The file is large, but moving exported API types now would cause broad import churn.
+- Reshaping `src/web_interface/control/modes.rs`. It is a candidate for a later `types.rs` / `handlers.rs` split, but doing that together with active Runtime Mode work would create unnecessary conflict risk.
+- Repository-wide rustfmt or line-ending changes. That remains a dedicated format policy task.
+
+## Validation
+
+- `cargo check`
+- `npm run check`
+- `npm run lint`
+- `npm run build`
+- `npm run test:e2e -- modes-planning.spec.ts observability-layout.spec.ts`

--- a/gui/src/lib/control/runtimeModes.ts
+++ b/gui/src/lib/control/runtimeModes.ts
@@ -1,0 +1,100 @@
+import { ControlApiError, type ModeTransitionPlan } from '../types';
+
+export type PlannedMode = {
+ id: string;
+ label: string;
+ description: string;
+ flowgraphGroups: string[];
+ managedApps: string[];
+ notifications: string;
+};
+
+export type DisplayMode = PlannedMode & {
+ configured: boolean;
+};
+
+export type ManagedDirectiveRow = {
+ label: string;
+ values: string[];
+};
+
+export const plannedModes: PlannedMode[] = [
+ {
+  id: 'daily',
+  label: 'Daily',
+  description: 'Assistant, alerts, and lightweight personal automations.',
+  flowgraphGroups: ['assistant', 'alerts', 'rss'],
+  managedApps: ['stop obs', 'stop warudo', 'stop tts'],
+  notifications: 'normal',
+ },
+ {
+  id: 'streaming',
+  label: 'Streaming',
+  description: 'Streaming stack, avatar tools, OBS control, and stream-safe alerts.',
+  flowgraphGroups: ['assistant', 'streaming', 'avatar', 'obs'],
+  managedApps: ['start obs', 'start warudo', 'start tts'],
+  notifications: 'stream_safe',
+ },
+ {
+  id: 'work',
+  label: 'Work',
+  description: 'Reduced interruptions while keeping critical alerts and assistant access.',
+  flowgraphGroups: ['assistant', 'alerts'],
+  managedApps: ['stop obs', 'stop warudo', 'stop tts'],
+  notifications: 'important_only',
+ },
+ {
+  id: 'sleep',
+  label: 'Sleep',
+  description: 'Only critical monitoring and emergency notification flows.',
+  flowgraphGroups: ['emergency_alerts'],
+  managedApps: ['stop obs', 'stop warudo', 'stop tts'],
+  notifications: 'critical_only',
+ },
+ {
+  id: 'rta',
+  label: 'RTA',
+  description: 'Game/run-specific timers, splits, alerts, and reduced background noise.',
+  flowgraphGroups: ['game', 'timer', 'alerts'],
+  managedApps: ['leave game tools', 'stop streaming extras'],
+  notifications: 'run_safe',
+ },
+];
+
+export function buildDisplayModes(configuredModeIds: string[]): DisplayMode[] {
+ const configured = new Set(configuredModeIds);
+ const known = new Set(plannedModes.map((m) => m.id));
+ const plannedRows = plannedModes.map((m) => ({ ...m, configured: configured.has(m.id) }));
+ const customRows = configuredModeIds
+  .filter((id) => !known.has(id))
+  .map((id) => ({
+   id,
+   label: id,
+   description: 'Configured runtime mode from conf.',
+   flowgraphGroups: ['configured'],
+   managedApps: ['use configured desired state'],
+   notifications: 'configured',
+   configured: true,
+  }));
+ return [...customRows, ...plannedRows];
+}
+
+export function managedDirectiveRows(plan: ModeTransitionPlan | null): ManagedDirectiveRow[] {
+ if (!plan) return [];
+ return [
+  { label: 'Start', values: plan.target_managed_apps.start },
+  { label: 'Stop', values: plan.target_managed_apps.stop },
+  { label: 'Minimize', values: plan.target_managed_apps.minimize },
+  { label: 'Leave', values: plan.target_managed_apps.leave },
+ ].filter((row) => row.values.length > 0);
+}
+
+export function formatControlApiError(e: unknown): string {
+ if (e instanceof ControlApiError) return `${e.status} ${e.statusText}`;
+ if (e instanceof Error) return e.message;
+ return String(e);
+}
+
+export function joinList(values: string[]): string {
+ return values.length > 0 ? values.join(', ') : '-';
+}

--- a/gui/src/lib/tabs/ModesTab.svelte
+++ b/gui/src/lib/tabs/ModesTab.svelte
@@ -2,67 +2,16 @@
  import { onMount } from 'svelte';
  import { api } from '../api';
  import {
-  ControlApiError,
+  buildDisplayModes,
+  formatControlApiError,
+  joinList,
+  managedDirectiveRows,
+ } from '../control/runtimeModes';
+ import {
   type ModeTransitionPlan,
   type RuntimeModeManagedAppOp,
   type RuntimeModeTransitionStatus,
  } from '../types';
-
- type PlannedMode = {
-  id: string;
-  label: string;
-  description: string;
-  flowgraphGroups: string[];
-  managedApps: string[];
-  notifications: string;
- };
-
- type DisplayMode = PlannedMode & {
-  configured: boolean;
- };
-
- const plannedModes: PlannedMode[] = [
-  {
-   id: 'daily',
-   label: 'Daily',
-   description: 'Assistant, alerts, and lightweight personal automations.',
-   flowgraphGroups: ['assistant', 'alerts', 'rss'],
-   managedApps: ['stop obs', 'stop warudo', 'stop tts'],
-   notifications: 'normal',
-  },
-  {
-   id: 'streaming',
-   label: 'Streaming',
-   description: 'Streaming stack, avatar tools, OBS control, and stream-safe alerts.',
-   flowgraphGroups: ['assistant', 'streaming', 'avatar', 'obs'],
-   managedApps: ['start obs', 'start warudo', 'start tts'],
-   notifications: 'stream_safe',
-  },
-  {
-   id: 'work',
-   label: 'Work',
-   description: 'Reduced interruptions while keeping critical alerts and assistant access.',
-   flowgraphGroups: ['assistant', 'alerts'],
-   managedApps: ['stop obs', 'stop warudo', 'stop tts'],
-   notifications: 'important_only',
-  },
-  {
-   id: 'sleep',
-   label: 'Sleep',
-   description: 'Only critical monitoring and emergency notification flows.',
-   flowgraphGroups: ['emergency_alerts'],
-   managedApps: ['stop obs', 'stop warudo', 'stop tts'],
-   notifications: 'critical_only',
-  },
-  {
-   id: 'rta',
-   label: 'RTA',
-   description: 'Game/run-specific timers, splits, alerts, and reduced background noise.',
-   flowgraphGroups: ['game', 'timer', 'alerts'],
-   managedApps: ['leave game tools', 'stop streaming extras'],
-   notifications: 'run_safe',
-  },
- ] as const;
 
  let configuredModeIds = $state<string[]>([]);
  let currentModeId = $state<string | null>(null);
@@ -78,23 +27,7 @@
  let managedAppOps = $state<RuntimeModeManagedAppOp[]>([]);
  let planRequestSeq = 0;
 
- const displayModes = $derived.by<DisplayMode[]>(() => {
-  const configured = new Set(configuredModeIds);
-  const known = new Set(plannedModes.map((m) => m.id));
-  const plannedRows = plannedModes.map((m) => ({ ...m, configured: configured.has(m.id) }));
-  const customRows = configuredModeIds
-   .filter((id) => !known.has(id))
-   .map((id) => ({
-    id,
-    label: id,
-    description: 'Configured runtime mode from conf.',
-    flowgraphGroups: ['configured'],
-    managedApps: ['use configured desired state'],
-    notifications: 'configured',
-    configured: true,
-   }));
-  return [...customRows, ...plannedRows];
- });
+ const displayModes = $derived(buildDisplayModes(configuredModeIds));
 
  const selectedMode = $derived(displayModes.find((m) => m.id === selectedModeId) ?? displayModes[0]);
  const managedDesiredRows = $derived(managedDirectiveRows(transitionPlan));
@@ -166,7 +99,7 @@
    if (current.mode) selectedModeId = current.mode;
    else if (list.mode_ids.length > 0) selectedModeId = list.mode_ids[0];
   } catch (e) {
-   loadError = formatError(e);
+   loadError = formatControlApiError(e);
   } finally {
    loading = false;
   }
@@ -187,7 +120,7 @@
    managedAppOps = next.managed_apps ?? [];
    await refreshTransitionStatus();
   } catch (e) {
-   mutationError = formatError(e);
+   mutationError = formatControlApiError(e);
   } finally {
    mutating = false;
   }
@@ -217,31 +150,12 @@
   } catch (e) {
    if (seq !== planRequestSeq) return;
    transitionPlan = null;
-   planError = formatError(e);
+   planError = formatControlApiError(e);
   } finally {
    if (seq === planRequestSeq) planLoading = false;
   }
  }
 
- function formatError(e: unknown): string {
-  if (e instanceof ControlApiError) return `${e.status} ${e.statusText}`;
-  if (e instanceof Error) return e.message;
-  return String(e);
- }
-
- function joinList(values: string[]): string {
-  return values.length > 0 ? values.join(', ') : '-';
- }
-
- function managedDirectiveRows(plan: ModeTransitionPlan | null): Array<{ label: string; values: string[] }> {
-  if (!plan) return [];
-  return [
-   { label: 'Start', values: plan.target_managed_apps.start },
-   { label: 'Stop', values: plan.target_managed_apps.stop },
-   { label: 'Minimize', values: plan.target_managed_apps.minimize },
-   { label: 'Leave', values: plan.target_managed_apps.leave },
-  ].filter((row) => row.values.length > 0);
- }
 </script>
 
 <section class="grid gap-4">

--- a/src/control_events.rs
+++ b/src/control_events.rs
@@ -212,6 +212,26 @@ pub enum ControlEvent {
 	},
 }
 
+impl ControlEvent {
+	pub fn kind(&self) -> &'static str {
+		match self {
+			ControlEvent::ChannelDatum { .. } => "channel_datum",
+			ControlEvent::Lagged { .. } => "lagged",
+			ControlEvent::Heartbeat { .. } => "heartbeat",
+			ControlEvent::PauseState { .. } => "pause_state",
+			ControlEvent::Reloaded { .. } => "reloaded",
+			ControlEvent::ProcessorInvoked { .. } => "processor_invoked",
+			ControlEvent::Restarting { .. } => "restarting",
+			ControlEvent::FlowgraphReloaded { .. } => "flowgraph_reloaded",
+			ControlEvent::ManagedAppState { .. } => "managed_app_state",
+			ControlEvent::RestartRecommended { .. } => "restart_recommended",
+			ControlEvent::RuntimeModeChanged { .. } => "runtime_mode_changed",
+			ControlEvent::RuntimeModeManagedApps { .. } => "runtime_mode_managed_apps",
+			ControlEvent::OAuthStatus { .. } => "oauth_status",
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/src/web_interface/control/events.rs
+++ b/src/web_interface/control/events.rs
@@ -33,7 +33,7 @@ pub async fn history(state: Data<SharedState>, query: Query<EventHistoryQuery>) 
 	let mut rows: Vec<_> = h
 		.iter()
 		.rev()
-		.filter(|item| kind.map(|k| control_event_kind(&item.event) == k).unwrap_or(true))
+		.filter(|item| kind.map(|k| item.event.kind() == k).unwrap_or(true))
 		.take(limit)
 		.cloned()
 		.collect();
@@ -42,22 +42,4 @@ pub async fn history(state: Data<SharedState>, query: Query<EventHistoryQuery>) 
 		"events": rows,
 		"limit": limit,
 	}))
-}
-
-fn control_event_kind(ev: &ControlEvent) -> &'static str {
-	match ev {
-		ControlEvent::ChannelDatum { .. } => "channel_datum",
-		ControlEvent::Lagged { .. } => "lagged",
-		ControlEvent::Heartbeat { .. } => "heartbeat",
-		ControlEvent::PauseState { .. } => "pause_state",
-		ControlEvent::Reloaded { .. } => "reloaded",
-		ControlEvent::ProcessorInvoked { .. } => "processor_invoked",
-		ControlEvent::Restarting { .. } => "restarting",
-		ControlEvent::FlowgraphReloaded { .. } => "flowgraph_reloaded",
-		ControlEvent::ManagedAppState { .. } => "managed_app_state",
-		ControlEvent::RestartRecommended { .. } => "restart_recommended",
-		ControlEvent::RuntimeModeChanged { .. } => "runtime_mode_changed",
-		ControlEvent::RuntimeModeManagedApps { .. } => "runtime_mode_managed_apps",
-		ControlEvent::OAuthStatus { .. } => "oauth_status",
-	}
 }


### PR DESCRIPTION
## Summary

Third maintenance slice after the health baseline and dependency refresh.

- extracted Runtime Mode display/planning helpers from `ModesTab.svelte` into `gui/src/lib/control/runtimeModes.ts`
- moved ControlEvent kind classification into `ControlEvent::kind()` and reused it from the event history endpoint
- added `docs/maintenance/structure-cleanup-2026-04-27.md` to document scope, deferred cleanup, and validation

## Validation

- `cargo check`
- `npm run check`
- `npm run lint`
- `npm run build`
- `npm run test:e2e -- modes-planning.spec.ts observability-layout.spec.ts`