### PR TITLE
[codex] Refresh Rust zip and build downloader deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ rmp-serde = "1.3"
 # キャッシュパス・LibreTranslate embed 展開
 dirs = "6.0"
 # LibreTranslate: embeddable Python zip 展開
-zip = { version = "2.2", default-features = false, features = ["deflate"] }
+zip = { version = "8.6", default-features = false, features = ["deflate"] }
 # 《Voice》: マイク入力（Vosk / Whisper 共通）
 cpal = "0.17"
 shlex = "1.3.0"
@@ -155,8 +155,8 @@ windows = { version = "0.62", features = [
 winapi = { version = "0.3.9", features = ["wincodec"] }
 
 [build-dependencies]
-ureq = { version = "2.10", default-features = false, features = ["tls"] }
-zip = { version = "2.2", default-features = false, features = ["deflate"] }
+ureq = { version = "3.3", default-features = false, features = ["rustls"] }
+zip = { version = "8.6", default-features = false, features = ["deflate"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,7 @@ fn ensure_vosk_win64_in_vendors() -> Result<PathBuf, String> {
 
 fn download_file(url: &str, dest: &Path) -> Result<(), String> {
 	let resp = ureq::get(url)
-		.set(
+		.header(
 			"User-Agent",
 			"virtual-avatar-connect/build.rs (Vosk vendor; https://github.com/alphacep/vosk-api)",
 		)
@@ -103,7 +103,7 @@ fn download_file(url: &str, dest: &Path) -> Result<(), String> {
 		return Err(format!("GET {} が HTTP {} を返しました", url, resp.status()));
 	}
 
-	let mut reader = resp.into_reader();
+	let mut reader = resp.into_parts().1.into_reader();
 	let mut f = fs::File::create(dest).map_err(|e| e.to_string())?;
 	std::io::copy(&mut reader, &mut f).map_err(|e| format!("保存: {}", e))?;
 	Ok(())

--- a/src/flowgraph/quantity/parser.rs
+++ b/src/flowgraph/quantity/parser.rs
@@ -23,6 +23,10 @@
 
 use super::prefix::SIPrefix;
 use super::unit::Unit;
+#[cfg(test)]
+use super::unit::BaseUnitId;
+#[cfg(test)]
+use std::collections::BTreeMap;
 
 /// Errors produced while parsing a unit string.
 #[derive(Debug, Clone, thiserror::Error)]


### PR DESCRIPTION
## Summary

- update `ureq` build dependency from the 2.x line to `3.3` and switch the TLS feature to `rustls`
- update both runtime and build `zip` dependencies from the 2.x line to `8.6`, keeping `default-features = false` and `deflate` only
- adjust `build.rs` for the `ureq 3` request/response API
- restore missing test-only imports in `quantity::parser` so lib test builds can run after the dependency update

## Validation

- `cargo check`
- `cargo test zip_codec`
- `cargo tree -i ureq` -> `ureq v3.3.0`
- `cargo tree -i zip` -> `zip v8.6.0` used by runtime and build dependencies