### PR TITLE
Polish GUI placeholder and navigation copy

### DIFF
--- a/gui/src/lib/WidgetSlot.svelte
+++ b/gui/src/lib/WidgetSlot.svelte
@@ -1,31 +1,24 @@
 <script lang="ts">
  /**
-  * Phase VI-γ-1: ウィジェット配置用のスロット土台。
+  * Lightweight placeholder shell for planned dashboard widgets.
   *
-  * γ-1 では **見た目としての領域** だけ提供し、ウィジェット自体（OBS 連携、`!bsr` キュー、
-  * Twitch チャット等）は γ-2 以降で個別に作り込んで差し込む。ここでは API だけ先に固める:
-  *
-  *   - `title` を指定するとボーダー付きのカードで枠を持つ
-  *   - 空スロットのときは "この領域にウィジェットを配置できます" のプレースホルダ
-  *   - `compact` で枠線なし・余白最小の variant（ステータスバー近くに並べるとき用）
-  *
-  * ここで作った interface は γ-2 以降の実ウィジェットを <WidgetSlot>...</WidgetSlot> で包むか、
-  * あるいは slot 経由で注入する方式のどちらでも扱えるようにしている。
+  * The component gives unfinished resource, settings, and utility surfaces a
+  * consistent frame until a concrete widget replaces the placeholder content.
   */
  import type { Snippet } from 'svelte';
 
  interface Props {
-  /** カード左上に小さく出す見出し。省略可。 */
+  /** Card title shown in the header. */
   title?: string;
-  /** 右上に出す副情報（プロフィール名など）。省略可。 */
+  /** Small header note, usually status or scope. */
   subtitle?: string;
-  /** 子要素。未指定時はプレースホルダを出す。 */
+  /** Optional real widget content. */
   children?: Snippet;
-  /** 枠・余白を最小化する。 */
+  /** Render without the dashed card frame. */
   compact?: boolean;
-  /** プレースホルダに出す説明文。未指定時は定形文。 */
+  /** Text shown while no widget content is mounted. */
   placeholder?: string;
-  /** ref 用の id（URL フラグメントや a11y 用）。 */
+  /** Optional region id for links and tests. */
   id?: string;
  }
 
@@ -34,7 +27,7 @@
   subtitle,
   children,
   compact = false,
-  placeholder = 'このスロットにウィジェットを配置できます（γ-2 以降で実装）。',
+  placeholder = 'This widget slot is reserved for a planned GUI surface.',
   id,
  }: Props = $props();
 </script>

--- a/gui/src/lib/tabs/FlowgraphTab.svelte
+++ b/gui/src/lib/tabs/FlowgraphTab.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
  /**
-  * Phase δ-6e: Flowgraph タブのトップレベル。
+  * Flowgraph Studio tab.
   *
-  * レイアウト:
-  *   ├── 上部: ツールバー（reload / save / open-external）
-  *   ├── 中央:
-  *   │    ├── 左サイドバー（ファイルツリー）
-  *   │    ├── キャンバス（Svelte Flow）
-  *   │    └── 右サイドバー（上: パレット / 下: プロパティエディタ）
-  *   └── 下部: 診断パネル
-  *
-  * 責務:
-  *   - マウント時に `flowgraphStore.refreshAll()` + WS 購読を開始
-  *   - アンマウント時に WS 購読を解除
-  *
-  * 子コンポーネントとの通信は `flowgraphStore` 経由。props は最小に保つ。
+  * Owns the high-level editor layout, command palette, keyboard shortcuts,
+  * and Flowgraph store lifecycle. Canvas, tree, palette, inspector, and
+  * diagnostics behavior stay in their focused child components.
   */
  import { onMount } from 'svelte';
  import { flowgraphStore, summarizeDiagnostics } from '../flowgraphStore.svelte';
@@ -45,7 +35,7 @@ type StudioCommand = {
 onMount(() => {
   void flowgraphStore.refreshAll();
   flowgraphStore.attachWsSubscriber();
-  // γ-4a: Ctrl+S / Cmd+S で現在ファイルを保存。フォーカスが input 系でも有効にするため window に付ける。
+  // Keep global editor shortcuts on window; form controls handle their own keys.
   const onKeyDown = (ev: KeyboardEvent) => {
    const t = ev.target as HTMLElement | null;
    if (t?.closest('input, textarea, select, [contenteditable="true"]')) return;
@@ -88,13 +78,13 @@ onMount(() => {
     ev.preventDefault();
     const ok = flowgraphStore.duplicateSelectedNode();
     if (ok) {
-     toastStore.success('複製しました', flowgraphStore.selectedNodeId ?? '');
+     toastStore.success('Duplicated', flowgraphStore.selectedNodeId ?? '');
     }
     return;
    }
   };
   window.addEventListener('keydown', onKeyDown);
-  // γ-4a: 未保存変更がある状態で閉じようとしたらブラウザにネイティブ確認ダイアログを出す。
+  // Ask the browser to confirm navigation while the current Flowgraph draft is dirty.
   const onBeforeUnload = (ev: BeforeUnloadEvent) => {
    if (!flowgraphStore.isDirty) return;
    ev.preventDefault();
@@ -110,7 +100,7 @@ onMount(() => {
 
  const isDirty = $derived(flowgraphStore.isDirty);
  const saveLabel = $derived(
-  flowgraphStore.mutating ? 'Saving…' : isDirty ? 'Save *' : 'Save',
+  flowgraphStore.mutating ? 'Saving...' : isDirty ? 'Save *' : 'Save',
  );
 
  const summary = $derived(summarizeDiagnostics(flowgraphStore.diagnostics?.diagnostics));
@@ -245,7 +235,7 @@ onMount(() => {
   return specs.slice(0, 250).map((spec) => ({
    id: `insert:${spec.feature}`,
    label: `Insert ${spec.title}`,
-   description: `${spec.category} · ${spec.feature}`,
+   description: `${spec.category} - ${spec.feature}`,
    disabled: !flowgraphStore.currentFq,
    run: () => {
     flowgraphStore.addCatalogNodeAt(spec, null);
@@ -279,7 +269,7 @@ async function onOpenExternal() {
 }
 
 async function onCopy() {
- // 選択中ノードがあればそれを、なければ現在ファイル全体を fragment 化。
+ // Copy selected nodes when available, otherwise copy the current file as a fragment.
  if (flowgraphStore.selectedNodeId) await flowgraphStore.fragmentCopySelectedNode();
  else await flowgraphStore.fragmentCopyCurrentFile();
 }
@@ -386,7 +376,7 @@ async function runStudioCommand(command: StudioCommand) {
   <button
    type="button"
    class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800"
-   title="ディスクから再ロード"
+   title="Reload Flowgraph files from disk"
    onclick={onReload}
   >
    Reload
@@ -395,7 +385,7 @@ async function runStudioCommand(command: StudioCommand) {
    type="button"
    class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800 disabled:opacity-40"
    disabled={!flowgraphStore.currentFq}
-   title="外部エディタで開く"
+   title="Open the selected Flowgraph file in an external editor"
    onclick={onOpenExternal}
   >
    Open external
@@ -404,7 +394,7 @@ async function runStudioCommand(command: StudioCommand) {
   type="button"
   class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800 disabled:opacity-40"
   disabled={!flowgraphStore.currentFq}
-  title="選択ノード、なければ現在ファイル全体を fragment TOML としてコピー"
+  title="Copy the selected nodes, or the current file when no node is selected"
   onclick={onCopy}
  >
   Copy
@@ -412,16 +402,16 @@ async function runStudioCommand(command: StudioCommand) {
  <button
   type="button"
   class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800"
-  title="fragment TOML を paste"
+  title="Paste a Flowgraph fragment"
   onclick={onPaste}
  >
-  Paste…
+  Paste...
  </button>
  <button
   type="button"
   class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800 disabled:opacity-40"
   disabled={!flowgraphStore.currentFq}
-  title="現在ファイルを ZIP でエクスポート"
+  title="Export the current Flowgraph file as a ZIP fragment"
   onclick={onExportZip}
  >
   Export ZIP
@@ -429,10 +419,10 @@ async function runStudioCommand(command: StudioCommand) {
  <button
   type="button"
   class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-200-800"
-  title="ZIP を import（dry_run preview → 本番）"
+  title="Import a ZIP fragment with preview before applying changes"
   onclick={onImportZip}
  >
-  Import ZIP…
+  Import ZIP...
  </button>
  <button
   type="button"
@@ -442,7 +432,7 @@ async function runStudioCommand(command: StudioCommand) {
   class:bg-warning-500={isDirty}
   class:hover:bg-warning-600={isDirty}
   disabled={!flowgraphStore.currentFq || flowgraphStore.mutating}
-  title={isDirty ? '未保存の変更があります（Ctrl+S）' : '現在のファイルを保存（Ctrl+S）'}
+  title={isDirty ? 'Unsaved changes. Press Ctrl+S to save.' : 'Save the current Flowgraph file. Press Ctrl+S.'}
   onclick={onSave}
  >
   {saveLabel}

--- a/gui/src/lib/tabs/ResourcesTab.svelte
+++ b/gui/src/lib/tabs/ResourcesTab.svelte
@@ -20,8 +20,8 @@
   <OAuthPanel />
   <WidgetSlot
    title="Avatar / OBS / TTS connectors"
-   subtitle="future resources"
-   placeholder="OBS、Warudo、TTS、avatar bridge などは Runtime Mode と連動する外部リソースとしてここに集約します。"
+   subtitle="planned resources"
+   placeholder="OBS, Warudo, TTS, and avatar bridges will live here as external resources coordinated by Runtime Mode."
   />
  </div>
 </div>

--- a/gui/src/lib/tabs/SettingsTab.svelte
+++ b/gui/src/lib/tabs/SettingsTab.svelte
@@ -18,13 +18,13 @@
  </div>
  <div class="space-y-4">
   <section class="rounded-lg border border-surface-200-800 bg-surface-100-900 p-4">
-   <h2 class="mb-2 text-sm font-semibold opacity-80">接続情報</h2>
+   <h2 class="mb-2 text-sm font-semibold opacity-80">Connection</h2>
    <PingStatus />
   </section>
   <WidgetSlot
-   title="開発者向けユーティリティ"
-   subtitle="γ-6 予定"
-   placeholder="ログダウンロード、ランタイム診断、ニッチな操作（broadcasters の force_remove 等）を整理します。"
+   title="Developer utilities"
+   subtitle="planned"
+   placeholder="Log download, runtime diagnostics, and rare maintenance operations will be grouped here."
   />
  </div>
 </div>

--- a/gui/src/lib/tabs/SetupTab.svelte
+++ b/gui/src/lib/tabs/SetupTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
  /**
-  * Setup タブ（γ-1 の骨組み）。既存の細々した運用パネルをここに集約し、
-  * γ-4 でプロファイル管理を統合した。
+  * Legacy setup tab kept for compatibility with old routes.
+  * New navigation splits these controls across Resources and Settings.
   */
  import WidgetSlot from '../WidgetSlot.svelte';
  import OAuthPanel from '../OAuthPanel.svelte';
@@ -21,9 +21,9 @@
  <div class="space-y-4">
   <RunWithEditorPanel />
   <WidgetSlot
-   title="Voice / AI / Twitch 詳細設定"
-   subtitle="Pipeline タブへ統合済み（γ-3b）"
-   placeholder="各 processor / AI persona の詳細プロパティは Pipeline タブ上でノードを選択して編集できます。"
+   title="Voice / AI / Twitch details"
+   subtitle="moved to Flowgraph Studio"
+   placeholder="Detailed processor and AI persona properties are edited by selecting nodes in Flowgraph Studio."
   />
  </div>
 </div>

--- a/gui/src/lib/tabs/ToolsTab.svelte
+++ b/gui/src/lib/tabs/ToolsTab.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
  /**
-  * Tools タブ（γ-1）。
+  * Legacy tools tab kept for compatibility with old routes.
   *
-  * 現状は γ-6 までの中継として、開発者向けの ping/whoami 情報や今後の小物を集める領域。
+  * Current navigation keeps connection checks and future developer utilities under Settings.
   */
  import PingStatus from '../PingStatus.svelte';
  import WidgetSlot from '../WidgetSlot.svelte';
@@ -10,12 +10,12 @@
 
 <div class="space-y-4">
  <section class="rounded-lg border border-surface-200-800 bg-surface-100-900 p-4">
-  <h2 class="mb-2 text-sm font-semibold opacity-80">接続情報</h2>
+  <h2 class="mb-2 text-sm font-semibold opacity-80">Connection</h2>
   <PingStatus />
  </section>
  <WidgetSlot
-  title="開発者向けユーティリティ"
-  subtitle="γ-6 予定"
-  placeholder="ログダウンロード、ランタイム診断、ニッチな操作（broadcasters の force_remove 等）を整理します。"
+  title="Developer utilities"
+  subtitle="planned"
+  placeholder="Log download, runtime diagnostics, and rare maintenance operations will be grouped here."
  />
 </div>

--- a/gui/tests/e2e/main-navigation.spec.ts
+++ b/gui/tests/e2e/main-navigation.spec.ts
@@ -19,21 +19,20 @@ test.describe('GUI redesign: main navigation', () => {
   await expect(page.getByText('root =')).toBeVisible({ timeout: 15_000 });
 
   await tabs.getByRole('button', { name: /resources/i }).click();
-  await expect(page.getByRole('heading', { name: '連携アプリ設定（run_with）' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'OAuth (Twitch Device Code Flow)' })).toBeVisible({
    timeout: 15_000,
   });
-  await expect(page.getByRole('heading', { name: 'OAuth (Twitch Device Code Flow)' })).toBeVisible();
 
   await tabs.getByRole('button', { name: /observability/i }).click();
-  await expect(page.getByRole('heading', { name: 'ライブイベント' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Observability' })).toBeVisible({
    timeout: 15_000,
   });
 
   await tabs.getByRole('button', { name: /settings/i }).click();
-  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Connection' })).toBeVisible({
    timeout: 15_000,
   });
-  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Developer utilities' })).toBeVisible({
   });
  });
 
@@ -44,20 +43,20 @@ test.describe('GUI redesign: main navigation', () => {
   });
 
   await page.goto(`/gui/${tokenQuery()}#setup`);
-  await expect(page.getByRole('heading', { name: '連携アプリ設定（run_with）' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'OAuth (Twitch Device Code Flow)' })).toBeVisible({
    timeout: 15_000,
   });
 
   await page.goto(`/gui/${tokenQuery()}#logs`);
-  await expect(page.getByRole('heading', { name: 'ライブイベント' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Observability' })).toBeVisible({
    timeout: 15_000,
   });
 
   await page.goto(`/gui/${tokenQuery()}#tools`);
-  await expect(page.getByRole('heading', { name: 'プロファイル管理' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Connection' })).toBeVisible({
    timeout: 15_000,
   });
-  await expect(page.getByRole('heading', { name: '接続情報' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Developer utilities' })).toBeVisible({
   });
  });
 });


### PR DESCRIPTION
## Summary

- polish placeholder copy for Resources, Settings, and legacy compatibility tabs
- clean the shared `WidgetSlot` comments and default placeholder text
- make Flowgraph Studio toolbar titles and progress labels consistent with the current English IA
- update main navigation E2E assertions to target stable current headings

## Validation

- `npm run check`
- `npm run lint`
- `npm run build`
- `npm run test:e2e -- main-navigation.spec.ts flowgraph-studio-layout.spec.ts`