### PR TITLE
Polish Managed Apps drawer copy

### DIFF
--- a/gui/src/App.svelte
+++ b/gui/src/App.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
  /**
-  * Phase VI-γ-1: アプリケーションシェル。
+  * Application shell for the v2 Runtime Cockpit.
   *
-  * - 上部ヘッダ（ロゴ / 接続インジケータ / 再起動ボタン）
-  * - 左ナビゲーション（Now / Modes / Flowgraph Studio / Resources / Observability / Settings）
-  * - 下部ステータスバー（常駐）
-  * - 右下トーストレイヤ
-  * - 再起動・プロファイル切替モーダル
-  *
-  * 各タブの中身はコンテナコンポーネントに切り出し、本ファイルは薄い shell に徹する。
-  *
-  * δ-9 D.5: 旧 V1 `Pipeline` タブを廃止。Flowgraph タブに統合済み。
+  * The shell owns top-level navigation, global status, toasts, restart/shutdown
+  * controls, and the persistent Managed Apps drawer. Feature surfaces stay in
+  * their tab components.
   */
  import ConnectionBadge from './lib/ConnectionBadge.svelte';
  import TabNav from './lib/TabNav.svelte';
@@ -32,34 +26,24 @@
  import { toastStore } from './lib/toasts.svelte';
 
  let restartDialogOpen = $state(false);
-let managedAppDrawerOpen = $state(false);
-let shutdownInFlight = $state(false);
+ let managedAppDrawerOpen = $state(false);
+ let shutdownInFlight = $state(false);
 
-/**
- * Phase ε-1: VAC プロセスそのものを穏やかに終了させる。
- *
- * 停止は `POST /api/v1/control/shutdown`（= `ShutdownBroker` を trigger）に 1 本化している。
- * 成功レスポンス後はサーバが ManagedApp 停止 → actix graceful stop を順に実行するため、
- * WS は自然に切れる。GUI 側は停止画面を出さず、toast だけ出して静かに待機する。
- */
-async function handleShutdownClick() {
- if (shutdownInFlight) return;
- const ok = window.confirm(
-  'VAC を終了します。連携アプリ（run_with で起動したもの）も停止を試み、\nブラウザの接続は切断されます。続行しますか？',
- );
- if (!ok) return;
- shutdownInFlight = true;
- try {
-  const res = await api.shutdown();
-  toastStore.info(
-   'アプリ停止を要求しました',
-   `pid=${res.current_pid} / status=${res.status}`,
+ async function handleShutdownClick(): Promise<void> {
+  if (shutdownInFlight) return;
+  const ok = window.confirm(
+   'Shutdown VAC?\n\nVAC will also try to stop Managed Apps started through run_with. Browser connections will close.',
   );
- } catch (e) {
-  shutdownInFlight = false;
-  toastStore.error('アプリ停止の要求に失敗しました', String(e));
+  if (!ok) return;
+  shutdownInFlight = true;
+  try {
+   const res = await api.shutdown();
+   toastStore.info('Shutdown requested.', `pid=${res.current_pid} / status=${res.status}`);
+  } catch (e) {
+   shutdownInFlight = false;
+   toastStore.error('Shutdown request failed.', String(e));
+  }
  }
-}
 </script>
 
 <div class="flex min-h-screen flex-col bg-surface-50-950 text-surface-950-50">
@@ -77,33 +61,33 @@ async function handleShutdownClick() {
     <button
      type="button"
      class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-100-900"
-     title="連携アプリ（run_with）の起動/停止を管理"
+     title="Open Managed Apps drawer"
      onclick={() => (managedAppDrawerOpen = true)}
     >
-     連携アプリ…
+     Managed Apps...
     </button>
     <button
      type="button"
      class="rounded border border-surface-300-700 px-3 py-1 text-xs hover:bg-surface-100-900"
-     title="VAC を再起動 / プロファイル切替"
+     title="Restart VAC or switch profile"
      onclick={() => (restartDialogOpen = true)}
     >
-     再起動…
+     Restart...
     </button>
     <button
      type="button"
      class="rounded border border-error-500/60 px-3 py-1 text-xs text-error-500 hover:bg-error-500/10 disabled:opacity-50"
-     title="VAC アプリを終了する（連携アプリの停止も試みる）"
+     title="Shutdown VAC and try to stop Managed Apps"
      disabled={shutdownInFlight}
      onclick={handleShutdownClick}
     >
-     {shutdownInFlight ? '停止中…' : '終了'}
+     {shutdownInFlight ? 'Shutting down...' : 'Shutdown'}
     </button>
    </div>
   </div>
  </header>
 
- <div class="grid flex-1 min-h-0 lg:grid-cols-[240px_minmax(0,1fr)]">
+ <div class="grid min-h-0 flex-1 lg:grid-cols-[240px_minmax(0,1fr)]">
   <aside class="border-b border-surface-200-800 bg-surface-100-900/60 lg:border-b-0 lg:border-r">
    <TabNav />
   </aside>

--- a/gui/src/lib/ManagedAppDrawer.svelte
+++ b/gui/src/lib/ManagedAppDrawer.svelte
@@ -1,72 +1,50 @@
 <script lang="ts">
  /**
-  * Phase VI-γ-2b: Managed App 持続ドロワー。
+  * Persistent Managed App drawer.
   *
-  * - ヘッダ右肩の「連携アプリ」ボタンで開閉。
-  * - 右側からスライドインし、アプリ一覧 + 各行の start/stop/minimize ボタンを置く。
-  * - WebSocket `managed_app_state` を購読してリアルタイム反映。
-  * - 操作ごとの軽量 toast を出す（api.ts 共通の error toast は request() 側で拾わないので、ここで投げる）。
-  *
-  * デザイン方針:
-  *   - shell は普通のアプリ風（見慣れた drawer）を優先。アクション失敗は目立つ警告色で見せる。
-  *   - 各行のボタンは「start = primary」「stop = error」「minimize = surface（Windows のみ）」の 3 つ。
-  *   - `supports_status=false` の entry は「状態不明」として扱い、start のみ許可。
+  * Lists apps registered through run_with and exposes explicit start, stop,
+  * restart, and minimize actions. The drawer also listens to managed_app_state
+  * WebSocket events so process state changes appear without a full refresh.
   */
  import { SvelteSet } from 'svelte/reactivity';
  import { api } from './api';
  import { eventsStore } from './events.svelte';
  import { toastStore } from './toasts.svelte';
- import {
-  ControlApiError,
-  type ControlEvent,
-  type ManagedAppView,
-  type ManagedAppsResponse,
- } from './types';
+ import { ControlApiError, type ControlEvent, type ManagedAppView, type ManagedAppsResponse } from './types';
 
  interface Props {
   open: boolean;
  }
+
  let { open = $bindable() }: Props = $props();
 
  let loading = $state(true);
  let error = $state<string | null>(null);
  let resp = $state<ManagedAppsResponse | null>(null);
- /** 操作中の app id セット。ボタンの spinner 表示に使う。SvelteSet で細粒度リアクティブ。 */
  const busyIds = new SvelteSet<string>();
 
- async function load() {
+ async function load(): Promise<void> {
   loading = true;
   error = null;
   try {
    resp = await api.managedApps();
   } catch (e) {
-   error =
-    e instanceof ControlApiError
-     ? `${e.status} ${e.statusText}`
-     : e instanceof Error
-      ? e.message
-      : String(e);
+   error = formatErr(e);
   } finally {
    loading = false;
   }
  }
 
  $effect(() => {
-  // open になったときに取得。閉じている間は購読だけ効かせておき、開く都度リフレッシュ。
-  if (open) {
-   void load();
-  }
+  if (open) void load();
  });
 
- // managed_app_state を受けたら対象 entry の status を上書き。全件再フェッチはしない（負荷軽減）。
  $effect(() => {
   const off = eventsStore.subscribe((ts) => {
    const ev: ControlEvent = ts.event;
-   if (ev.kind !== 'managed_app_state') return;
-   if (!resp) return;
-   const idx = resp.entries.findIndex((e) => e.id === ev.id);
+   if (ev.kind !== 'managed_app_state' || !resp) return;
+   const idx = resp.entries.findIndex((entry) => entry.id === ev.id);
    if (idx < 0) return;
-   // 新しい status で entry を差し替え（配列自体も新規化してリアクティブに拾わせる）
    const next = resp.entries.slice();
    next[idx] = {
     ...next[idx],
@@ -82,76 +60,73 @@
   return off;
  });
 
- function setBusy(id: string, busy: boolean) {
+ function setBusy(id: string, busy: boolean): void {
   if (busy) busyIds.add(id);
   else busyIds.delete(id);
  }
 
- async function actStart(entry: ManagedAppView) {
+ async function actStart(entry: ManagedAppView): Promise<void> {
   setBusy(entry.id, true);
   try {
    const r = await api.managedAppStart(entry.id);
-   if (r.was_running) {
-    toastStore.warn(`${entry.label} は既に起動中です`);
-   } else {
-    toastStore.success(`${entry.label} を起動しました`);
-   }
+   if (r.was_running) toastStore.warn(`${entry.label} is already running.`);
+   else toastStore.success(`Started ${entry.label}.`);
   } catch (e) {
    const msg = formatErr(e);
-   if (e instanceof ControlApiError && e.status === 409) {
-    toastStore.warn(`${entry.label} は既に起動中です`, msg);
-   } else {
-    toastStore.error(`${entry.label} の起動に失敗`, msg);
-   }
+   if (e instanceof ControlApiError && e.status === 409) toastStore.warn(`${entry.label} is already running.`, msg);
+   else toastStore.error(`Failed to start ${entry.label}.`, msg);
   } finally {
    setBusy(entry.id, false);
   }
  }
 
- async function actStop(entry: ManagedAppView) {
-  // 誤爆回避のため軽く確認
-  if (!confirm(`${entry.label} を停止しますか？\nWM_CLOSE → 3 秒待機 → 強制終了 の順で試みます。`)) return;
+ async function actStop(entry: ManagedAppView): Promise<void> {
+  const ok = confirm(
+   `Stop ${entry.label}?\n\nVAC will request close, wait briefly, then force-terminate remaining tracked PIDs if needed.`,
+  );
+  if (!ok) return;
   setBusy(entry.id, true);
   try {
    const r = await api.managedAppStop(entry.id, { grace_ms: 3000 });
    if (r.terminated_pids > 0) {
     toastStore.warn(
-     `${entry.label} を強制終了しました`,
+     `Force-stopped ${entry.label}.`,
      `closed=${r.closed_windows}, terminated=${r.terminated_pids}`,
     );
    } else {
-    toastStore.success(`${entry.label} にクローズ要求を送りました`, `closed_windows=${r.closed_windows}`);
+    toastStore.success(`Requested close for ${entry.label}.`, `closed_windows=${r.closed_windows}`);
    }
   } catch (e) {
-   toastStore.error(`${entry.label} の停止に失敗`, formatErr(e));
+   toastStore.error(`Failed to stop ${entry.label}.`, formatErr(e));
   } finally {
    setBusy(entry.id, false);
   }
  }
 
- async function actRestart(entry: ManagedAppView) {
- if (!confirm(`${entry.label} を再起動しますか？\n（停止 → 起動 の順で実行します）`)) return;
- setBusy(entry.id, true);
- try {
-  const r = await api.managedAppRestart(entry.id, { grace_ms: 3000 });
-  const stoppedPart = r.was_running
-   ? `stopped (closed=${r.closed_windows}, terminated=${r.terminated_pids})`
-   : '起動していませんでした';
-  toastStore.success(`${entry.label} を再起動しました`, stoppedPart);
- } catch (e) {
-  toastStore.error(`${entry.label} の再起動に失敗`, formatErr(e));
- } finally {
-  setBusy(entry.id, false);
+ async function actRestart(entry: ManagedAppView): Promise<void> {
+  const ok = confirm(`Restart ${entry.label}?\n\nVAC will stop the tracked process first, then start it again.`);
+  if (!ok) return;
+  setBusy(entry.id, true);
+  try {
+   const r = await api.managedAppRestart(entry.id, { grace_ms: 3000 });
+   const detail = r.was_running
+    ? `stopped closed=${r.closed_windows}, terminated=${r.terminated_pids}`
+    : 'was not running before restart';
+   toastStore.success(`Restarted ${entry.label}.`, detail);
+  } catch (e) {
+   toastStore.error(`Failed to restart ${entry.label}.`, formatErr(e));
+  } finally {
+   setBusy(entry.id, false);
+  }
  }
-}
 
-async function actMinimize(entry: ManagedAppView) {
+ async function actMinimize(entry: ManagedAppView): Promise<void> {
   setBusy(entry.id, true);
   try {
    const r = await api.managedAppMinimize(entry.id);
-   toastStore.info(`${entry.label} を最小化キューに入れました`, `pids=${r.scheduled_pids}`);
+   toastStore.info(`Queued minimize for ${entry.label}.`, `pids=${r.scheduled_pids}`);
   } catch (e) {
-   toastStore.error(`${entry.label} の最小化に失敗`, formatErr(e));
+   toastStore.error(`Failed to minimize ${entry.label}.`, formatErr(e));
   } finally {
    setBusy(entry.id, false);
   }
@@ -164,9 +139,10 @@ async function actMinimize(entry: ManagedAppView) {
  }
 
  function statusLabel(entry: ManagedAppView): string {
-  if (!entry.supports_status) return '状態不明';
-  return entry.status.running ? '起動中' : '停止';
+  if (!entry.supports_status) return 'untracked';
+  return entry.status.running ? 'running' : 'stopped';
  }
+
  function statusClass(entry: ManagedAppView): string {
   if (!entry.supports_status) return 'bg-surface-300-700 text-surface-900-100';
   return entry.status.running
@@ -174,34 +150,32 @@ async function actMinimize(entry: ManagedAppView) {
    : 'bg-error-300-700/60 text-error-900-100';
  }
 
- function close() {
+ function close(): void {
   open = false;
  }
 
- function onBackdropKey(e: KeyboardEvent) {
+ function onBackdropKey(e: KeyboardEvent): void {
   if (e.key === 'Escape') close();
  }
 </script>
 
 {#if open}
- <!-- backdrop: 半透明オーバーレイ。クリックで閉じる -->
  <div
   class="fixed inset-0 z-40 bg-surface-950/40 backdrop-blur-sm"
   role="button"
   tabindex="-1"
-  aria-label="連携アプリドロワーを閉じる"
+  aria-label="Close managed apps drawer"
   onclick={close}
   onkeydown={onBackdropKey}
  ></div>
- <!-- drawer 本体 -->
  <aside
   class="fixed right-0 top-0 z-50 flex h-screen w-full max-w-md flex-col border-l border-surface-200-800 bg-surface-50-950 shadow-xl"
-  aria-label="Managed app drawer"
+  aria-label="Managed Apps"
  >
   <header class="flex items-center justify-between border-b border-surface-200-800 px-4 py-3">
    <div>
-    <h2 class="text-sm font-semibold">連携アプリ</h2>
-    <p class="text-xs opacity-60">run_with で管理するアプリの監視と操作</p>
+    <h2 class="text-sm font-semibold">Managed Apps</h2>
+    <p class="text-xs opacity-60">Monitor and control apps registered through run_with.</p>
    </div>
    <div class="flex items-center gap-2">
     <button
@@ -210,29 +184,28 @@ async function actMinimize(entry: ManagedAppView) {
      onclick={() => void load()}
      disabled={loading}
     >
-     再読込
+     Refresh
     </button>
     <button
      type="button"
      class="rounded border border-surface-300-700 px-2 py-0.5 text-xs hover:bg-surface-100-900"
-     aria-label="閉じる"
+     aria-label="Close"
      onclick={close}
     >
-     ×
+     x
     </button>
    </div>
   </header>
 
   <div class="flex-1 overflow-y-auto p-3">
    {#if loading}
-    <p class="text-xs opacity-70">読み込み中…</p>
+    <p class="text-xs opacity-70">Loading...</p>
    {:else if error}
     <p class="rounded border border-error-500/40 bg-error-500/10 p-2 text-xs">{error}</p>
    {:else if !resp || resp.entries.length === 0}
     <p class="rounded border border-warning-500/40 bg-warning-500/10 p-2 text-xs">
-     登録済みの Managed App がありません。<br />
-     <code>conf.toml</code> の <code>[[run_with]]</code> エントリに
-     <code>if_not_running = "プロセス名"</code> を書いてください。
+     No Managed Apps are registered.<br />
+     Add <code>run_with</code> entries with <code>if_not_running</code> markers to track process state.
     </p>
    {:else}
     <ul class="space-y-2">
@@ -277,7 +250,7 @@ async function actMinimize(entry: ManagedAppView) {
          onclick={() => void actStart(entry)}
          disabled={busy || (entry.supports_status && entry.status.running)}
         >
-         起動
+         Start
         </button>
         <button
          type="button"
@@ -285,25 +258,25 @@ async function actMinimize(entry: ManagedAppView) {
          onclick={() => void actStop(entry)}
          disabled={busy || !canStop}
         >
-         停止
+         Stop
         </button>
         <button
          type="button"
          class="rounded border border-warning-500 px-2 py-1 text-xs font-semibold text-warning-500 hover:bg-warning-500 hover:text-white disabled:opacity-30"
          onclick={() => void actRestart(entry)}
          disabled={busy || !entry.supports_status}
-         title="停止 → 起動 の連続操作"
+         title="Stop and then start the tracked app"
         >
-         再起動
+         Restart
         </button>
         <button
          type="button"
          class="rounded border border-surface-300-700 px-2 py-1 text-xs hover:bg-surface-200-800 disabled:opacity-30"
          onclick={() => void actMinimize(entry)}
          disabled={busy || !canMinimize}
-         title="Windows 専用"
+         title="Windows-only minimize request"
         >
-         最小化
+         Minimize
         </button>
        </div>
       </li>

--- a/gui/tests/e2e/managed-app-drawer.spec.ts
+++ b/gui/tests/e2e/managed-app-drawer.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+import { tokenQuery } from './fixtures';
+
+test.describe('GUI shell: Managed Apps drawer', () => {
+ test('opens the drawer from the shell action', async ({ page }) => {
+  await page.goto(`/gui/${tokenQuery()}`);
+
+  await page.getByRole('button', { name: 'Managed Apps...' }).click();
+
+  const drawer = page.getByRole('complementary', { name: 'Managed Apps' });
+  await expect(drawer.getByRole('heading', { name: 'Managed Apps' })).toBeVisible({
+   timeout: 15_000,
+  });
+  await expect(drawer.getByText('Monitor and control apps registered through run_with.')).toBeVisible();
+  await expect(drawer.getByRole('button', { name: 'Refresh' })).toBeVisible();
+  await expect(drawer.getByRole('button', { name: 'Close' })).toBeVisible();
+ });
+});


### PR DESCRIPTION
## Summary

- polish the shell Managed Apps / Restart / Shutdown actions to match the English Runtime Cockpit IA
- rewrite the Managed Apps drawer copy, confirmations, empty state, status labels, and toast text in clear operational English
- keep the existing Managed App API behavior and WebSocket status refresh path unchanged
- add focused Playwright coverage for opening the Managed Apps drawer from the shell

## Validation

- `npm run check`
- `npm run lint`
- `npm run build`
- `npm run test:e2e -- now-dashboard.spec.ts resources-overview.spec.ts`
- `npm run test:e2e -- managed-app-drawer.spec.ts`